### PR TITLE
Add a Tabs landing page

### DIFF
--- a/js/actions/index.js
+++ b/js/actions/index.js
@@ -1,5 +1,6 @@
 const breakpoints = require("./breakpoints");
 const eventListeners = require("./event-listeners");
 const sources = require("./sources");
+const tabs = require("./tabs");
 
-module.exports = Object.assign({}, breakpoints, eventListeners, sources);
+module.exports = Object.assign({}, breakpoints, eventListeners, sources, tabs);

--- a/js/actions/tabs.js
+++ b/js/actions/tabs.js
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+const { Task } = require('devtools/sham/task');
+const { PROMISE } = require('devtools/client/shared/redux/middleware/promise');
+
+const { connectToTab} = require('../client');
+const constants = require('../constants');
+const { getTabs } = require('../queries');
+
+function newTabs(tabs) {
+  return {
+    type: constants.ADD_TABS,
+    value: tabs
+  };
+}
+
+function selectTab({ tabActor }) {
+  return (dispatch, getState) => {
+    const tabs = getTabs(getState());
+    const selectedTab = tabs[tabActor];
+
+    // set selected tab in the URL hash
+    const childId = tabActor.match(/child\d+/)[0];
+    window.location.hash = `tab=${childId}`
+
+    return dispatch({
+      type: constants.SELECT_TAB,
+      tabActor: tabActor,
+      [PROMISE]: Task.spawn(function*() {
+        yield connectToTab(selectedTab);
+        return { selectedTab };
+      })
+    });
+  }
+}
+
+module.exports = {
+  newTabs,
+  selectTab
+};

--- a/js/client.js
+++ b/js/client.js
@@ -1,0 +1,34 @@
+const { DebuggerClient } = require('devtools/shared/client/main');
+const { DebuggerTransport } = require('devtools/transport/transport');
+const { TargetFactory } = require("devtools/client/framework/target");
+const promise = require('devtools/sham/promise');
+
+const socket = new WebSocket("ws://localhost:9000");
+const transport = new DebuggerTransport(socket);
+const client = new DebuggerClient(transport);
+
+function connectToClient(onConnect) {
+  client.connect().then(() => {
+    return client.listTabs().then(onConnect);
+  }).catch(err => console.log(err));
+}
+
+function connectToTab(tab, onNewSource) {
+  let deferred =  promise.defer();
+  const options = { client, form: tab, chrome: false };
+
+  TargetFactory.forRemoteTab(options).then(target => {
+    target.activeTab.attachThread({}, (res, threadClient) => {
+      threadClient.resume();
+      window.gThreadClient = threadClient;
+      deferred.resolve();
+    });
+  });
+
+  return deferred.promise;
+}
+
+module.exports = {
+  connectToClient,
+  connectToTab
+};

--- a/js/components/Breakpoints.js
+++ b/js/components/Breakpoints.js
@@ -5,7 +5,7 @@ function Breakpoints({ breakpoints }) {
 
   function onResumeClick() {
     console.log('click')
-    gThreadClient.resume()
+    gThreadClient.resume();
   }
 
   return dom.div(

--- a/js/components/TabList.css
+++ b/js/components/TabList.css
@@ -1,0 +1,4 @@
+.tablist {
+  flex: 1;
+  overflow: 'hidden';
+}

--- a/js/components/TabList.js
+++ b/js/components/TabList.js
@@ -1,0 +1,26 @@
+const React = require("react");
+const { connect } = require("react-redux");
+const dom = React.DOM;
+
+require('./TabList.css');
+const App = React.createFactory(require('./app'));
+const Tabs = React.createFactory(require('./tabs'));
+const { getSelectedTab } = require('../queries');
+
+function isEmpty(obj) {
+  return Object.keys(obj).length == 0;
+}
+
+function TabList({ selectedTab }) {
+  const container =  isEmpty(selectedTab) ? Tabs() : App();
+
+  return dom.div({
+      className: 'tablist'
+    },
+    container
+  );
+}
+
+module.exports = connect(
+  state => ({ selectedTab: getSelectedTab(state) })
+)(TabList);

--- a/js/components/Tabs.css
+++ b/js/components/Tabs.css
@@ -1,0 +1,28 @@
+.tabs {
+  list-style: none;
+  margin: 100px auto;
+  width: calc(100% - 200px);
+  border-top: 1px solid #ddd;
+  padding: 0;
+}
+
+.tabs .tab {
+  border-bottom: 1px solid #ddd;
+  padding: 10px;
+  font-family: sans-serif;
+  font-size: .75em;
+}
+
+.tabs .tab:hover {
+  background-color: var(--theme-toolbar-background);
+  cursor: pointer;
+}
+
+.tabs .tab-title {
+    line-height: 25px;
+    color: var(--theme-content-color1);
+}
+
+.tabs .tab-url {
+  color: var(--theme-highlight-bluegrey);
+}

--- a/js/components/Tabs.js
+++ b/js/components/Tabs.js
@@ -1,0 +1,46 @@
+const React = require("react");
+const ReactDOM = require("react-dom");
+const { bindActionCreators } = require("redux");
+const { connect } = require("react-redux");
+const { getTabs } = require("../queries");
+const actions = require("../actions")
+
+require("./tabs.css");
+const dom = React.DOM;
+
+function Tabs({tabs, selectTab, loadSources}) {
+  const tabsArr = Object.keys(tabs).map(k => tabs[k]);
+
+  /**
+   * TODO: this click handler is probably doing too much right now.
+   */
+  function onClickTab(e) {
+    selectTab({ tabActor: e.currentTarget.dataset.actorId })
+      .then(loadSources)
+      .then(() => {
+        gThreadClient.addListener("newSource", (event, packet) => {
+          store.dispatch(actions.newSource(packet.source));
+        });
+        gThreadClient.addListener("paused", (_, packet) => {
+          console.log(packet);
+        });
+      })
+  }
+
+  return dom.ul(
+    {className: 'tabs'},
+    tabsArr.map(tab => {
+      return dom.li({ 'className': 'tab',
+                      'data-actor-id': tab.actor,
+                      'onClick': onClickTab },
+        dom.div({ className: 'tab-title' }, tab.title),
+        dom.div({ className: 'tab-url' }, tab.url)
+      )
+    })
+  );
+}
+
+module.exports = connect(
+  state => ({ tabs: getTabs(state) }),
+  dispatch => bindActionCreators(actions, dispatch)
+)(Tabs);

--- a/js/constants.js
+++ b/js/constants.js
@@ -23,3 +23,6 @@ exports.LOAD_SOURCE_TEXT = 'LOAD_SOURCE_TEXT';
 exports.SELECT_SOURCE = 'SELECT_SOURCE';
 exports.UNLOAD = 'UNLOAD';
 exports.RELOAD = 'RELOAD';
+
+exports.ADD_TABS = 'ADD_TABS';
+exports.SELECT_TAB = 'SELECT_TAB';

--- a/js/main.js
+++ b/js/main.js
@@ -4,51 +4,60 @@ const { combineReducers, applyMiddleware, bindActionCreators } = require('redux'
 const { Provider } = require('react-redux');
 const configureStore = require('./create-store');
 const reducers = require('./reducers');
+const { connectToClient } = require('./client');
 const actions = require('./actions');
-const App = require('./components/app');
 const dom = React.DOM;
-
-const { DebuggerClient } = require('devtools/shared/client/main');
-const { DebuggerTransport } = require('devtools/transport/transport');
-const { TargetFactory } = require("devtools/client/framework/target");
-const socket = new WebSocket("ws://localhost:9000");
-const transport = new DebuggerTransport(socket);
-const client = new DebuggerClient(transport);
-
-client.connect().then(() => {
-  return client.listTabs().then(response => {
-    const tab = response.tabs[response.selected];
-    const options = { form: tab, client, chrome: false };
-    TargetFactory.forRemoteTab(options).then(target => {
-      target.activeTab.attachThread({}, (res, threadClient) => {
-        threadClient.resume();
-        window.gThreadClient = threadClient;
-        connectThread(gThreadClient);
-      });
-    });
-  });
-}).catch(err => console.log(err));
+const TabList = React.createFactory(require('./components/TabList'));
 
 const createStore = configureStore({ log: true });
 const store = createStore(combineReducers(reducers));
+window.store = store; // global for debugging purposes only!
 
-function connectThread(threadClient) {
-  threadClient.addListener("newSource", (event, packet) => {
-    store.dispatch(actions.newSource(packet.source));
-  });
+connectToClient(response => {
+  const tabs = response.tabs;
+  store.dispatch(actions.newTabs(response.tabs));
 
-  threadClient.addListener("paused", (_, packet) => {
-    console.log(packet);
-  });
+  // if there's a pre-selected tab, connect to it and load the sources.
+  // otherwise, just show the toolbox.
+  if (hasSelectedTab()){
+    const selectedTab = getSelectedTab(tabs);
+    store.dispatch(actions.selectTab({tabActor: selectedTab.actor}))
+      .then(() => store.dispatch(actions.loadSources()))
+      .then(renderToolbox)
+  } else {
+    renderToolbox();
+  }
+});
 
-  store.dispatch(actions.loadSources())
+/**
+ * Check to see if the url hash has a selected tab
+ * e.g. #tab=child2
+ */
+function hasSelectedTab() {
+  return window.location.hash.includes("tab");
 }
 
-ReactDOM.render(
-  React.createElement(
-    Provider,
-    { store },
-    React.createElement(App)
-  ),
-  document.querySelector('#mount')
-);
+/**
+ * get the selected tab from the url hash
+ * e.g. #tab=child2
+ *
+ * tabs are keyed by their child id,
+ * this is because the actor connection id increments every refresh and
+ * tab id is always 1.
+ *
+ */
+function getSelectedTab(tabs) {
+  const childId = window.location.hash.split("=")[1];
+  return tabs.find((tab) => tab.actor.includes(childId));
+}
+
+function renderToolbox() {
+  ReactDOM.render(
+    React.createElement(
+      Provider,
+      { store },
+      TabList()
+    ),
+    document.querySelector('#mount')
+  );
+}

--- a/js/queries.js
+++ b/js/queries.js
@@ -51,6 +51,14 @@ function getBreakpoint(state, location) {
   return state.breakpoints.breakpoints[makeLocationId(location)];
 }
 
+function getTabs(state) {
+  return state.tabs.tabs;
+}
+
+function getSelectedTab(state) {
+  return state.tabs.selectedTab;
+}
+
 function makeLocationId(location) {
   return location.actor + ':' + location.line.toString();
 }
@@ -66,5 +74,7 @@ module.exports = {
   getSourceText,
   getBreakpoint,
   getBreakpoints,
+  getTabs,
+  getSelectedTab,
   makeLocationId
 };

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -7,10 +7,12 @@ const eventListeners = require('./event-listeners');
 const sources = require('./sources');
 const breakpoints = require('./breakpoints');
 const asyncRequests = require('./async-requests');
+const tabs = require('./tabs');
 
 module.exports = {
   eventListeners,
   sources,
   breakpoints,
-  asyncRequests
+  asyncRequests,
+  tabs
 };

--- a/js/reducers/tabs.js
+++ b/js/reducers/tabs.js
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+const constants = require('../constants');
+const Immutable = require('seamless-immutable');
+const { mergeIn, setIn } = require('../utils');
+
+const initialState = Immutable({
+  tabs: {},
+  selectedTab: {},
+});
+
+function update(state = initialState, action) {
+  switch(action.type) {
+  case constants.ADD_TABS:
+    const tabs = action.value;
+    if (!tabs) {
+      return state;
+    }
+
+    const tabsByActor = {};
+    tabs.forEach(source => {
+      tabsByActor[source.actor] = source;
+    });
+
+    return mergeIn(state, ['tabs'], state.tabs.merge(tabsByActor));
+  case constants.SELECT_TAB:
+      if (action.status == "start") {
+        return state;
+      }
+      return mergeIn(state, ['selectedTab'], state.selectedTab.merge(action.value.selectedTab));
+  }
+
+  return state;
+}
+
+
+module.exports = update;


### PR DESCRIPTION
The tabs landing page shows the tabs that are ready to be debugged.
Currently, you re-select the tab you want to debug each time you
refresh, but we'll hopefully make it possible to select a tab and
refresh, without losing your selection shortly. I think the most natural
approach is to add a hash url.

http://recordit.co/otL3a1ly8C

Changes:

There's a new Toolbox component, Tabs component, action, and reducer.
At some point it would be nice to pull these pieces out of the debugger.

The protocol logic was moved into a thread-client module, which exposes
connectToClient and connectToTab methods. This is probably the most
important thing to review.