### PR TITLE
Add CSS Linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "debugger-experiment",
   "scripts": {
-    "start": "firefox-proxy & ./node_modules/.bin/webpack --watch"
+    "start": "firefox-proxy & ./node_modules/.bin/webpack --watch",
+    "lint-css": "stylelint js/components/*.css"
   },
   "dependencies": {
     "co": "=4.6.0",
@@ -15,6 +16,7 @@
     "react-redux": "=4.4.1",
     "redux": "=3.3.1",
     "seamless-immutable": "=5.1.1",
+    "stylelint": "^5.3.0",
     "webpack": "=1.12.14",
     "ws": "^1.0.1"
   },

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  "rules": {
+    "color-no-invalid-hex": true,
+    "declaration-colon-space-after": "always",
+    "max-empty-lines": 2,
+    "indentation": 2,
+  }
+}


### PR DESCRIPTION
[Stylelint](http://stylelint.io/) is a popular CSS linter with lots of [rules](http://stylelint.io/user-guide/rules/), which will let us keep the CSS clean.

I added a simple config, which checks for bad hex, 2 space indentation, and a couple other small knits. There's a good [example](https://github.com/stylelint/stylelint-config-standard/blob/master/index.js) with many more rules we can add in the future.

Questions:
+ are we in consensus that we want a linter?
+ not a blocker, but would we like to add linting on PRs with a service like travis?
+ what kind of rules would like to add?


Example:

I ran stylelint on our codebase and got this [gist](https://gist.github.com/536309bfd7d8f17bb23e47abfc6f9ba7), which is an argument for adding a linter sooner rather than later.
