### PR TITLE
Fix newSource event

### DIFF
--- a/js/components/Tabs.js
+++ b/js/components/Tabs.js
@@ -8,7 +8,7 @@ const actions = require("../actions")
 require("./tabs.css");
 const dom = React.DOM;
 
-function Tabs({tabs, selectTab, loadSources}) {
+function Tabs({ tabs, selectTab, loadSources, newSource }) {
   const tabsArr = Object.keys(tabs).map(k => tabs[k]);
 
   /**
@@ -19,7 +19,7 @@ function Tabs({tabs, selectTab, loadSources}) {
       .then(loadSources)
       .then(() => {
         gThreadClient.addListener("newSource", (event, packet) => {
-          store.dispatch(actions.newSource(packet.source));
+          newSource(packet.source);
         });
         gThreadClient.addListener("paused", (_, packet) => {
           console.log(packet);


### PR DESCRIPTION
When the event handlers were extracted, the store and actions
references were lost. This fixes that by accessing newSource
with bindActionCreator.