### PR TITLE
Add Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "5"
+install:
+  - npm install
+script:
+  - npm run lint-css
+  - npm run lint-js


### PR DESCRIPTION
This adds a travis ci build for PRs, with `lint-css` and `lint-js`.

The build looks something like this [run](https://travis-ci.org/jasonLaster/debugger.html/builds/121795864)

You can enable travis by going to your [profile](https://travis-ci.org/profile/jlongster).

What should we do with the fails? We have two options

1) fix them quickly (could just be turning off some rules we don't want to do now)

2) use a regression task that checks for new errors.

This would look like some variant of this bash script that computes the diff:

```
FIRST_RUN=`eslint js`
git patch apply # or something like this
SECOND_RUN=`eslint js`

echo `diff FIRST_RUN SECOND_RUN | egrep '^>' 
```
Because we don't have that many errors, I'd opt for squashing them early next week.