### PR TITLE
add test runner

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -19,11 +19,14 @@ const allPaths = paths.reduce((acc, path) => {
     const files = fs.readdirSync(path);
     return acc.concat.apply(
       acc,
-      files.map(file => join(path, file))
+      files.filter(p => p[0] !== '.').map(file => join(path, file))
     );
   }
   else {
-    return acc.concat([path]);
+    if(path[0] !== '.') {
+      return acc.concat([path]);
+    }
+    return acc;
   }
 }, []);
 
@@ -32,12 +35,19 @@ allPaths.forEach(path => {
   allEntries[path.replace(/\//g, '-')] = resolve(path);
 });
 
+
 const config = Object.assign({}, webpackConfig, {
   entry: allEntries,
   output: {
     path: join(__dirname, '../build/tests'),
     filename: '[name].js',
-    library: 'run_test'
+    library: 'run_test',
+  },
+  module: {
+    loaders: [{
+      test: /tests\/.*\.js$/,
+      loader: join(__dirname, "test-loader")
+    }]
   },
   devtool: null
 });
@@ -48,6 +58,6 @@ webpack(config).run(function(err, stats) {
   } else if(stats.compilation.errors.length) {
     console.log(stats.toString({ colors: true }));
   } else {
-    runTests(env.firefoxSrcDir, env.firefoxObjDir, [resolve('build/tests')]);
+    runTests(env.firefoxSrcDir, env.firefoxObjDir, ['build/tests']);
   }
 });

--- a/bin/test
+++ b/bin/test
@@ -1,26 +1,53 @@
 #!/usr/bin/env node
 "use strict";
 
-const join = require("path").join;
+const fs = require("fs");
 const runTests = require("xpcshell-unit-test");
 const webpack = require("webpack");
+const join = require("path").join
+const resolve = require("path").resolve;
+const rimraf = require("rimraf");
 const env = require(__dirname + "/../environment.json");
 const webpackConfig = require("../webpack.config");
 
 const paths = process.argv.slice(2);
 
-// runTests(env.firefoxSrcDir, env.firefoxObjDir,
+rimraf.sync(join(__dirname, '../build/tests'));
 
-paths.map(path => {
-  webpack(Object.assign({}, webpackConfig, {
-    entry: path,
-    output: {
-      path: join(__dirname, '../build'),
-      filename: path.replace('/', '-')
-    }
-  })).run(function(err, stats) {
-    console.log(err, stats);
-  });
+const allPaths = paths.reduce((acc, path) => {
+  if(fs.statSync(path).isDirectory()) {
+    const files = fs.readdirSync(path);
+    return acc.concat.apply(
+      acc,
+      files.map(file => join(path, file))
+    );
+  }
+  else {
+    return acc.concat([path]);
+  }
+}, []);
+
+const allEntries = {};
+allPaths.forEach(path => {
+  allEntries[path.replace(/\//g, '-')] = resolve(path);
 });
 
-//}));
+const config = Object.assign({}, webpackConfig, {
+  entry: allEntries,
+  output: {
+    path: join(__dirname, '../build/tests'),
+    filename: '[name].js',
+    library: 'run_test'
+  },
+  devtool: null
+});
+
+webpack(config).run(function(err, stats) {
+  if(err) {
+    console.log("ERROR", err);
+  } else if(stats.compilation.errors.length) {
+    console.log(stats.toString({ colors: true }));
+  } else {
+    runTests(env.firefoxSrcDir, env.firefoxObjDir, [resolve('build/tests')]);
+  }
+});

--- a/bin/test-loader.js
+++ b/bin/test-loader.js
@@ -1,0 +1,5 @@
+function testLoader(source) {
+  return source + "\n\n module.exports = run_test;\n";
+}
+
+module.exports = testLoader;

--- a/js/components/App.js
+++ b/js/components/App.js
@@ -12,13 +12,13 @@ const SplitBox = React.createFactory(require("./SplitBox"));
 const { getSources, getBreakpoints, getSelectedSource } = require("../queries");
 
 const App = React.createClass({
-  displayName: "App",
-
   propTypes: {
     sources: PropTypes.object,
     selectedSource: PropTypes.object,
     breakpoints: PropTypes.array
   },
+
+  displayName: "App",
 
   render: function() {
     return dom.div(

--- a/js/components/Breakpoints.js
+++ b/js/components/Breakpoints.js
@@ -8,12 +8,12 @@ const { getSources } = require("../queries");
 require("./Breakpoints.css");
 
 const Breakpoints = React.createClass({
-  displayName: "Breakpoints",
-
   propTypes: {
     breakpoints: PropTypes.array,
     sources: PropTypes.object
   },
+
+  displayName: "Breakpoints",
 
   render() {
     function onResumeClick() {

--- a/js/components/SplitBox.js
+++ b/js/components/SplitBox.js
@@ -10,7 +10,6 @@ require("./SplitBox.css");
 const { DOM: dom, PropTypes } = React;
 
 const SplitBox = React.createClass({
-
   propTypes: {
     left: PropTypes.any.isRequired,
     right: PropTypes.any.isRequired,

--- a/js/reducers/tests/sources-2.js
+++ b/js/reducers/tests/sources-2.js
@@ -1,5 +1,6 @@
+
 const sources = require('../sources.js');
 
 module.exports = () => {
-  equal(1, 1);
+  equal(2, 1);
 }

--- a/js/reducers/tests/sources-2.js
+++ b/js/reducers/tests/sources-2.js
@@ -1,6 +1,0 @@
-
-const sources = require('../sources.js');
-
-module.exports = () => {
-  equal(2, 1);
-}

--- a/js/reducers/tests/sources.js
+++ b/js/reducers/tests/sources.js
@@ -1,5 +1,4 @@
-const sources = require('../sources.js');
 
-module.exports = () => {
+function run_test() {
   equal(1, 1);
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-mozilla": "0.0.3",
     "eslint-plugin-react": "^4.3.0",
     "extract-text-webpack-plugin": "^1.0.1",
+    "rimraf": "^2.5.2",
     "style-loader": "^0.13.1",
     "xpcshell-unit-test": "0.0.2"
   }


### PR DESCRIPTION
This adds a test runner.

It's pretty janky. We need to compile each test with webpack which makes things a lot harder. Currently we compile everything as a separate entry point with a single webpack command in to the `build/tests` directory, and invoke the xpcshell runner on that. The `build/tests` directory is recursively removed each run to make sure it's fresh.

It works. We'll have to use it a little bit to see if it works well enough. All we need is something that will run for 3 months until we merge it.

I don't think mocha is a good idea because we will already have a lot of to when merging our code back in. I think it would be just too obtrusive to the merge, but we can investigate other solutions.

**Don't merge this yet**, because I want to test it some more. Just wanted to put it up here now.