### PR TITLE
Refactor breakpoints

### DIFF
--- a/js/components/Breakpoints.js
+++ b/js/components/Breakpoints.js
@@ -8,6 +8,30 @@ const { getSources } = require("../queries");
 
 require("./Breakpoints.css");
 
+function getFilenameFromSources(sources, actor) {
+  const source = sources[actor];
+  const url = new URL(source.url);
+  const filename = url.pathname.substring(
+    url.pathname.lastIndexOf("/") + 1);
+  return filename;
+}
+
+function Breakpoint(sources, breakpoint) {
+  const sourceActor = breakpoint.location.actor;
+
+  const filename = getFilenameFromSources(
+    sources,
+    sourceActor
+  );
+
+  const line = breakpoint.location.line;
+
+  return dom.li(
+    { key: `${sourceActor}/${line}` },
+    `${filename}, line ${line}`
+  );
+}
+
 const Breakpoints = React.createClass({
   propTypes: {
     breakpoints: PropTypes.array,
@@ -22,24 +46,12 @@ const Breakpoints = React.createClass({
       gThreadClient.resume();
     }
 
-    function getFilenameFromSources(sources, actor) {
-      const source = sources[actor];
-      const url = new URL(source.url);
-      const filename = url.pathname.substring(
-        url.pathname.lastIndexOf("/") + 1);
-      return filename;
-    }
-
     return dom.div(
       { className: "breakpoints" },
       dom.button({ onClick: onResumeClick }, "resume"),
       dom.ul(
         null,
-        this.props.breakpoints.map(bp => dom.li(
-          null,
-          getFilenameFromSources(this.props.sources, bp.location.actor)
-            + ", line " + bp.location.line)
-        )
+        this.props.breakpoints.map(bp => Breakpoint(this.props.sources, bp))
       )
     );
   }


### PR DESCRIPTION
Adds a `key` prop for each breakpoint to make React happy.

Also does a couple refactors:
1. creates a Breakpoint stateless component
2. pull getFilenameFromSources into the module context. Eventually, I'd like to have a query that fetches breakpoints with a full source, but I'd like to wait until we have re-select.