### PR TITLE
improve breakpoints

### DIFF
--- a/js/actions/breakpoints.js
+++ b/js/actions/breakpoints.js
@@ -89,7 +89,7 @@ function removeBreakpoint(location) {
 }
 
 function _removeOrDisableBreakpoint(location, isDisabled) {
-  return (dispatch, getState) => {
+  return ({ dispatch, getState }) => {
     let bp = getBreakpoint(getState(), location);
     if (!bp) {
       throw new Error("attempt to remove breakpoint that does not exist");
@@ -100,10 +100,10 @@ function _removeOrDisableBreakpoint(location, isDisabled) {
       throw new Error("attempt to remove unsaved breakpoint");
     }
 
-    const bpClient = getBreakpointClient(bp.actor);
+    const bpClient = getBreakpointClient(bp.get("actor"));
     const action = {
       type: constants.REMOVE_BREAKPOINT,
-      breakpoint: bp,
+      breakpoint: bp.toJS(),
       disabled: isDisabled
     };
 
@@ -121,7 +121,7 @@ function _removeOrDisableBreakpoint(location, isDisabled) {
 }
 
 function removeAllBreakpoints() {
-  return (dispatch, getState) => {
+  return ({ dispatch, getState }) => {
     const breakpoints = getBreakpoints(getState());
     const activeBreakpoints = breakpoints.filter(bp => !bp.disabled);
     activeBreakpoints.forEach(bp => removeBreakpoint(bp.location));

--- a/js/components/Sources.js
+++ b/js/components/Sources.js
@@ -1,11 +1,12 @@
 "use strict";
 
 const React = require("react");
-const {DOM: dom} = React;
 const { bindActionCreators } = require("redux");
 const { connect } = require("react-redux");
 const actions = require("../actions");
 const { getSelectedSource } = require("../queries");
+const { DOM: dom } = React;
+
 require("./Sources.css");
 
 function renderSource({source, selectSource, selectedSource}) {

--- a/js/queries.js
+++ b/js/queries.js
@@ -17,8 +17,18 @@ function getSelectedSourceOpts(state) {
   return state.sources.get("selectedSourceOpts");
 }
 
+function getBreakpoint(state, location) {
+  return state.breakpoints.getIn(["breakpoints", makeLocationId(location)]);
+}
+
 function getBreakpoints(state) {
   return state.breakpoints.get("breakpoints");
+}
+
+function getBreakpointsForSource(state, sourceActor) {
+  return state.breakpoints.get("breakpoints").filter(bp => {
+    return bp.getIn(["location", "actor"]) === sourceActor;
+  });
 }
 
 function getTabs(state) {
@@ -52,19 +62,6 @@ function getSourceByActor(state, actor) {
 
 function getSourceText(state, actor) {
   return getSourcesText(state).get(actor);
-}
-
-function getBreakpoint(state, location) {
-  return getBreakpoints(state).get(makeLocationId(location));
-}
-
-function getBreakpointByActor(state) {
-  return getBreakpoints(state).valueSeq()
-    .groupBy(bp => bp.getIn(["location", "actor"]));
-}
-
-function getBreakpointsForSource(state, actor) {
-  return getBreakpointByActor(state).get(actor);
 }
 
 /**

--- a/js/reducers/breakpoints.js
+++ b/js/reducers/breakpoints.js
@@ -52,7 +52,7 @@ function update(state = initialState, action) {
           // conform to the regular { actor, line } location shape, but
           // it has a `source` field. We should fix that.
           actualLocation = { actor: actualLocation.source.actor,
-                           line: actualLocation.line };
+                             line: actualLocation.line };
 
           state = state.deleteIn(["breakpoints", id]);
 


### PR DESCRIPTION
**Not ready to be merged**

This makes it so you can remove breakpoints and makes our immutable usage more consistent. We still need to figure some things out: right now we are treating anything passed through actions as normal JS objects. This is because you frequently do `this.props.fireAction({ x: 1})` so you can easily pass an object. However now we need to remember to do `this.props.fireAction(obj.toJS())` if we are using something from the existing state, like a breakpoint location. I'm sure we can figure this out; we could make actions detect if a parameter is immutable and coerce it to a JS object or something like that. Not exactly sure yet.

We also need to make the editor render breakpoints better. This still adds/removes a breakpoint on gutter click, but we really need to always rerender breakpoints whenever the state changes. For example, the server may "move" a breakpoint, and our UI breaks when the happens because the editor doesn't know to move the original bp that we added. If we always rendered from the state the bp would just magically move because the state changed.

But there are perf implications for doing that, so we need to do some kind of manual diffing of the breakpoint state and what's currently in the editor. Still more to research, and I'd like to do that before this is merged, but wanted to get this up.