### PR TITLE
Karma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,14 @@ node_js:
   - "5"
 install:
   - npm install
+before_install:
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 script:
   - npm run lint-css
   - npm run lint-js
   - npm run test
+  - npm run test-karma
+addons:
+  firefox: latest

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,34 @@
+"use strict";
+
+module.exports = function(config) {
+  let configuration = {
+    basePath: "",
+    frameworks: ["mocha"],
+    files: [
+      // Uses the node test runner because babel is required
+      "build/test-bundle.js"
+    ],
+    exclude: [],
+    preprocessors: {},
+    reporters: ["progress"],
+    port: 8002,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: false,
+    customLaunchers: {
+      Chrome_travis_ci: {
+        base: "Chrome",
+        flags: ["--no-sandbox"]
+      }
+    },
+    singleRun: false,
+    concurrency: Infinity
+  };
+
+  if (process.env.TRAVIS) {
+    configuration.browsers = ["Chrome_travis_ci", "Firefox"];
+  } else {
+    config.browsers = ["Firefox", "Chrome"];
+  }
+  config.set(configuration);
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "lint-css": "stylelint js/components/*.css",
     "lint-js": "eslint js",
     "test": "./bin/test-node js/actions/tests",
-    "test-browser": "./bin/test-browser js/actions/tests"
+    "test-browser": "./bin/test-browser js/actions/tests",
+    "test-karma": "./node_modules/.bin/karma start --single-run"
   },
   "dependencies": {
     "babel-cli": "^6.7.5",
@@ -17,6 +18,7 @@
     "ff-devtools-libs": "^0.1.1",
     "immutable": "^3.7.6",
     "json-loader": "^0.5.4",
+    "karma": "^0.13.22",
     "mocha": "^2.4.5",
     "net": "^1.0.2",
     "node-static": "^0.7.7",
@@ -42,6 +44,9 @@
     "eslint-plugin-mozilla": "0.0.3",
     "eslint-plugin-react": "^4.3.0",
     "extract-text-webpack-plugin": "^1.0.1",
+    "karma-chrome-launcher": "^0.2.3",
+    "karma-firefox-launcher": "^0.1.7",
+    "karma-mocha": "^0.2.2",
     "rimraf": "^2.5.2",
     "style-loader": "^0.13.1"
   }


### PR DESCRIPTION
Adds karma, which can be run with this command `karma start`

Also adds karma to travis, which will run tests on firefox and chrome. I
tried to add phantomjs and found that we would need to babel in some
features, so i passed for the time being.

NOTE: currently uses the node bundle because for some reason chrome and canary are complaining when the bundle is not babelfied.