### PR TITLE
Convert Action argument destructuring to list

### DIFF
--- a/js/actions/breakpoints.js
+++ b/js/actions/breakpoints.js
@@ -41,7 +41,7 @@ function _getOrCreateBreakpoint(state, location, condition) {
 }
 
 function addBreakpoint(location, condition) {
-  return ({ dispatch, getState, threadClient }) => {
+  return (dispatch, getState, threadClient) => {
     if (_breakpointExists(getState(), location)) {
       return promise.resolve();
     }
@@ -139,7 +139,7 @@ function removeAllBreakpoints() {
  *         A promise that will be resolved with the breakpoint client
  */
 function setBreakpointCondition(location, condition) {
-  return ({ dispatch, getState, threadClient }) => {
+  return (dispatch, getState, threadClient) => {
     const bp = getBreakpoint(getState(), location);
     if (!bp) {
       throw new Error("Breakpoint does not exist at the specified location");

--- a/js/actions/sources.js
+++ b/js/actions/sources.js
@@ -21,7 +21,7 @@ const FETCH_SOURCE_RESPONSE_DELAY = 200;
  * Handler for the debugger client's unsolicited newSource notification.
  */
 function newSource(source) {
-  return ({ dispatch }) => {
+  return (dispatch) => {
     // Ignore bogus scripts, e.g. generated from 'clientEvaluate' packets.
     if (NEW_SOURCE_IGNORED_URLS.indexOf(source.url) != -1) {
       return (new Promise()).resolve();
@@ -35,7 +35,7 @@ function newSource(source) {
 }
 
 function selectSource(source, opts) {
-  return ({ dispatch, getState, threadClient }) => {
+  return (dispatch, getState, threadClient) => {
     if (!threadClient) {
       // No connection, do nothing. This happens when the debugger is
       // shut down too fast and it tries to display a default source.
@@ -56,7 +56,7 @@ function selectSource(source, opts) {
 }
 
 function loadSources() {
-  return ({ dispatch, threadClient }) => {
+  return (dispatch, getState, threadClient) => {
     dispatch({
       type: constants.LOAD_SOURCES,
       [PROMISE]: Task.spawn(function* () {
@@ -97,7 +97,7 @@ function loadSources() {
  *          [aSource, error].
  */
 function blackbox(source, shouldBlackBox) {
-  return ({ dispatch, threadClient }) => {
+  return (dispatch, getState, threadClient) => {
     const client = threadClient.source(source);
 
     dispatch({
@@ -125,7 +125,7 @@ function blackbox(source, shouldBlackBox) {
  *          [aSource, error].
  */
 function togglePrettyPrint(source) {
-  return ({ dispatch, getState, threadClient }) => {
+  return (dispatch, getState, threadClient) => {
     const sourceClient = threadClient.source(source);
     const wantPretty = !source.isPrettyPrinted;
 
@@ -164,7 +164,7 @@ function togglePrettyPrint(source) {
 }
 
 function loadSourceText(source) {
-  return ({ dispatch, getState, threadClient }) => {
+  return (dispatch, getState, threadClient) => {
     // Fetch the source text only once.
     let textInfo = getSourceText(getState(), source.actor);
     if (textInfo) {
@@ -214,7 +214,7 @@ function loadSourceText(source) {
  *         A promise that is resolved after source texts have been fetched.
  */
 function getTextForSources(actors) {
-  return ({ dispatch, getState }) => {
+  return (dispatch, getState) => {
     let deferred = promise.defer();
     let pending = new Set(actors);
     let fetched = [];

--- a/js/actions/tabs.js
+++ b/js/actions/tabs.js
@@ -18,7 +18,7 @@ function newTabs(tabs) {
 }
 
 function selectTab({ tabActor }) {
-  return ({ dispatch, getState }) => {
+  return (dispatch, getState) => {
     const tabs = getTabs(getState());
     const selectedTab = tabs.get(tabActor);
 

--- a/js/main.js
+++ b/js/main.js
@@ -14,7 +14,8 @@ const TabList = React.createFactory(require("./components/TabList"));
 const createStore = configureStore({
   log: false,
   makeThunkArgs: args => {
-    return Object.assign({}, args, { threadClient: getThreadClient() });
+    const { dispatch, getState } = args;
+    return [ dispatch, getState, getThreadClient() ];
   }
 });
 const store = createStore(combineReducers(reducers));

--- a/js/util/thunk-middleware.js
+++ b/js/util/thunk-middleware.js
@@ -12,9 +12,12 @@ function thunk(makeArgs) {
     const args = { dispatch, getState };
 
     return next => action => {
-      return (typeof action === "function")
-        ? action(makeArgs ? makeArgs(args) : args)
-        : next(action);
+      if (typeof action === "function") {
+        const actionArgs = makeArgs ? makeArgs(args) : args;
+        return action.apply(undefined, actionArgs);
+      }
+
+      return next(action);
     };
   };
 }


### PR DESCRIPTION
This fixes chrome devtools pause crash, which would happen when there
was a destructured param.

old 
```js
return ({ dispatch, getState, threadClient }) => {}
```

new
```js
return (dispatch, getState, threadClient) => {}
```
