### PR TITLE
Fix chrome param destructuring bug

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,14 @@
 const path = require("path");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 
-module.exports = {
+let environment;
+try {
+  environment = require("./environment");
+} catch (e) {
+  environment = {};
+}
+
+let config = {
   entry: "./js/main.js",
   devtool: "source-map",
   output: {
@@ -34,3 +41,18 @@ module.exports = {
     new ExtractTextPlugin("styles.css")
   ]
 };
+
+// NOTE: This is only needed to fix a bug with chrome devtools' debugger and
+// destructuring params https://github.com/jlongster/debugger.html/issues/67
+if (environment.transformParameters) {
+  config.module.loaders.push({
+    test: /\.js$/,
+    exclude: /(node_modules|bower_components)/,
+    loader: "babel",
+    query: {
+      plugins: ["transform-es2015-parameters"]
+    }
+  });
+}
+
+module.exports = config;


### PR DESCRIPTION
I found a couple more examples of parameter destructuring ([1](https://github.com/jlongster/debugger.html/blob/master/js/components/Sources.js#L38-L41), [2](https://github.com/jlongster/debugger.html/blob/master/js/components/Sources.js#L11-L12)) while testing.

If it's not an action specific problem, I think it makes sense to let Babel solve the problem for those who want to opt-in. Babel bumps the build from ~2 to ~3 seconds, but more importantly, opens the door to features not yet supported, so I feel like it should be off by default.

One advantage to this solution, is that we can revert the action destructuring that we're currently doing, which should be made unnecessary. 