### PR TITLE
Add Debugger Commands

### DIFF
--- a/js/actions/index.js
+++ b/js/actions/index.js
@@ -4,5 +4,7 @@ const breakpoints = require("./breakpoints");
 const eventListeners = require("./event-listeners");
 const sources = require("./sources");
 const tabs = require("./tabs");
+const pause = require("./pause");
 
-module.exports = Object.assign({}, breakpoints, eventListeners, sources, tabs);
+module.exports = Object.assign(
+  {}, breakpoints, eventListeners, sources, tabs, pause);

--- a/js/actions/pause.js
+++ b/js/actions/pause.js
@@ -1,0 +1,65 @@
+"use strict";
+
+const constants = require("../constants");
+
+/**
+ * Debugger has just resumed
+ */
+function resumed() {
+  return ({ dispatch, threadClient }) => {
+    return dispatch({
+      type: constants.RESUME,
+      value: undefined
+    });
+  };
+}
+
+/**
+ * Debugger has just paused
+ */
+function paused(pauseInfo) {
+  return ({ dispatch }) => {
+    return dispatch({
+      type: constants.PAUSED,
+      value: pauseInfo
+    });
+  };
+}
+
+/**
+ * Debugger commands like stepOver, stepIn, stepUp
+ */
+function command({type}) {
+  return ({ dispatch, threadClient }) => {
+    // execute debugger thread command e.g. stepIn, stepOver
+    threadClient[type]();
+
+    return dispatch({
+      type: constants.COMMAND,
+      value: undefined
+    });
+  };
+}
+
+/**
+ * Debugger breakOnNext command.
+ * It's different from the comand action because we also want to
+ * highlight the pause icon.
+ */
+function breakOnNext() {
+  return ({ dispatch, threadClient }) => {
+    threadClient.breakOnNext();
+
+    return {
+      type: constants.BREAK_ON_NEXT,
+      value: true
+    };
+  };
+}
+
+module.exports = {
+  resumed,
+  paused,
+  command,
+  breakOnNext
+};

--- a/js/components/App.js
+++ b/js/components/App.js
@@ -1,16 +1,15 @@
 "use strict";
 
 const React = require("react");
-const { DOM: dom, PropTypes } = React;
+const { PropTypes } = React;
 const { connect } = require("react-redux");
 
 require("./App.css");
 require("../lib/variables.css");
 const Sources = React.createFactory(require("./Sources"));
 const Editor = React.createFactory(require("./Editor"));
-const Breakpoints = React.createFactory(require("./Breakpoints"));
-const Accordion = React.createFactory(require("./Accordion"));
 const SplitBox = React.createFactory(require("./SplitBox"));
+const RightSidebar = React.createFactory(require("./RightSidebar"));
 const { getSources, getBreakpoints, getSelectedSource } = require("../queries");
 
 const App = React.createClass({
@@ -30,16 +29,7 @@ const App = React.createClass({
         initialWidth: 300,
         rightFlex: true,
         left: Editor({ selectedSource: this.props.selectedSource }),
-        right: Accordion({
-          items: [
-            { header: "Breakpoints",
-              component: Breakpoints,
-              opened: true },
-            { header: "Foo",
-              component: () => dom.div(null, "hi")
-            }
-          ]
-        })
+        right: RightSidebar()
       })
     });
   }

--- a/js/components/Breakpoints.js
+++ b/js/components/Breakpoints.js
@@ -1,4 +1,3 @@
-/* globals URL gThreadClient */
 "use strict";
 
 const React = require("react");
@@ -36,6 +35,15 @@ function renderBreakpoint(sources, breakpoint) {
   );
 }
 
+function renderBreakpointList(breakpoints, sources) {
+  return dom.ul(
+    null,
+    breakpoints.valueSeq().map(bp => {
+      return renderBreakpoint(sources, bp);
+    })
+  );
+}
+
 const Breakpoints = React.createClass({
   propTypes: {
     breakpoints: ImPropTypes.map.isRequired,
@@ -44,36 +52,12 @@ const Breakpoints = React.createClass({
 
   displayName: "Breakpoints",
 
-  onResumeClick() {
-    gThreadClient.resume();
-  },
-
-  onStepOverClick() {
-    gThreadClient.stepOver();
-  },
-
-  onStepInClick() {
-    gThreadClient.stepIn();
-  },
-
-  onStepOutClick() {
-    gThreadClient.stepOut();
-  },
-
   render() {
     return dom.div(
       { className: "breakpoints" },
-      dom.div(null,
-        dom.button({ onClick: this.onResumeClick }, "Resume"),
-        dom.button({ onClick: this.onStepOverClick }, "Over"),
-        dom.button({ onClick: this.onStepInClick }, "In"),
-        dom.button({ onClick: this.onStepOutClick }, "Out")
-      ),
-      dom.ul(
-        null,
-        this.props.breakpoints.valueSeq().map(bp => {
-          return renderBreakpoint(this.props.sources, bp);
-        })
+      (this.props.breakpoints.size
+        ? renderBreakpointList(this.props.breakpoints, this.props.sources)
+        : dom.div({className: "pane-info"}, "No Breakpoints")
       )
     );
   }

--- a/js/components/Editor.css
+++ b/js/components/Editor.css
@@ -12,3 +12,17 @@
   fill: var(--theme-selection-background);
   width: 40px;
 }
+
+.CodeMirror-line {
+  font-family: Menlo, monospace !important;
+}
+
+.debug-line .CodeMirror-line {
+  background-color: var(--breakpoint-active-color) !important;
+}
+
+/* Don't display the highlight color since the debug line
+   is already highlighted */
+.debug-line .CodeMirror-activeline-background {
+  display: none;
+}

--- a/js/components/RightSidebar.css
+++ b/js/components/RightSidebar.css
@@ -1,0 +1,24 @@
+.right-sidebar {
+  flex: 1;
+}
+
+.command-bar {
+  border-bottom: 1px solid #cccccc;
+  height: 30px;
+  padding: 5px;
+}
+
+.command-bar button {
+  margin-right: 5px;
+}
+
+.accordion ._content {
+  font-size: 0.75em;
+  color: var(--theme-body-color);
+  padding: 5px;
+}
+
+.accordion .pane-info {
+  font-style: italic;
+  text-align: center;
+}

--- a/js/components/RightSidebar.css
+++ b/js/components/RightSidebar.css
@@ -8,8 +8,8 @@
   padding: 5px;
 }
 
-.command-bar button {
-  margin-right: 5px;
+.command-bar span {
+  margin-right: 8px;
 }
 
 .accordion ._content {

--- a/js/components/RightSidebar.js
+++ b/js/components/RightSidebar.js
@@ -1,0 +1,47 @@
+"use strict";
+
+const React = require("react");
+const { DOM: dom } = React;
+const { connect } = require("react-redux");
+const { bindActionCreators } = require("redux");
+const { getPause } = require("../queries");
+
+const actions = require("../actions");
+const Breakpoints = React.createFactory(require("./Breakpoints"));
+const Accordion = React.createFactory(require("./Accordion"));
+require("./RightSidebar.css");
+
+function RightSidebar({ resume, command, breakOnNext, pause }) {
+  return (
+    dom.div({className: "right-sidebar"},
+      dom.div({className: "command-bar"},
+        (
+          pause
+            ? dom.button({ onClick: () => command({type: "resume"}) }, "Resume")
+            : dom.button({ onClick: breakOnNext }, "Pause")
+        ),
+        dom.button({ onClick: () => command({type: "stepOver"}) }, "Over"),
+        dom.button({ onClick: () => command({type: "stepIn"}) }, "In"),
+        dom.button({ onClick: () => command({type: "stepOut"}) }, "Out")
+      ),
+      Accordion({
+        items: [
+          { header: "Breakpoints",
+            component: Breakpoints,
+            opened: true },
+          { header: "Call Stack",
+            component: () => dom.div({className: "pane-info"}, "Not Paused")
+          },
+          { header: "Scopes",
+            component: () => dom.div({className: "pane-info"}, "Not Paused")
+          }
+        ]
+      })
+    )
+  );
+}
+
+module.exports = connect(
+  state => ({ pause: getPause(state) }),
+  dispatch => bindActionCreators(actions, dispatch)
+)(RightSidebar);

--- a/js/components/RightSidebar.js
+++ b/js/components/RightSidebar.js
@@ -5,11 +5,19 @@ const { DOM: dom } = React;
 const { connect } = require("react-redux");
 const { bindActionCreators } = require("redux");
 const { getPause } = require("../queries");
+const Isvg = React.createFactory(require("react-inlinesvg"));
 
 const actions = require("../actions");
 const Breakpoints = React.createFactory(require("./Breakpoints"));
 const Accordion = React.createFactory(require("./Accordion"));
 require("./RightSidebar.css");
+
+function debugBtn(onClick, type) {
+  return dom.span(
+    { onClick },
+    Isvg({ src: `js/components/images/${type}.svg`})
+  );
+}
 
 function RightSidebar({ resume, command, breakOnNext, pause }) {
   return (
@@ -17,12 +25,12 @@ function RightSidebar({ resume, command, breakOnNext, pause }) {
       dom.div({className: "command-bar"},
         (
           pause
-            ? dom.button({ onClick: () => command({type: "resume"}) }, "Resume")
-            : dom.button({ onClick: breakOnNext }, "Pause")
+            ? debugBtn(() => command({ type: "resume" }), "resume")
+            : debugBtn(breakOnNext, "pause")
         ),
-        dom.button({ onClick: () => command({type: "stepOver"}) }, "Over"),
-        dom.button({ onClick: () => command({type: "stepIn"}) }, "In"),
-        dom.button({ onClick: () => command({type: "stepOut"}) }, "Out")
+        debugBtn(() => command({ type: "stepOver" }), "stepOver"),
+        debugBtn(() => command({ type: "stepIn" }), "stepIn"),
+        debugBtn(() => command({ type: "stepOut" }), "stepOut")
       ),
       Accordion({
         items: [

--- a/js/components/Tabs.js
+++ b/js/components/Tabs.js
@@ -1,30 +1,21 @@
-/* globals gThreadClient */
 "use strict";
 
 const React = require("react");
-const { bindActionCreators } = require("redux");
 const { connect } = require("react-redux");
-const { getTabs } = require("../queries");
 const actions = require("../actions");
+const { bindActionCreators } = require("redux");
+const { getTabs } = require("../queries");
+const { debugTab } = require("../client");
 
 require("./Tabs.css");
 const dom = React.DOM;
 
-function Tabs({ tabs, selectTab, loadSources, newSource }) {
-  /**
-   * TODO: this click handler is probably doing too much right now.
-   */
+function Tabs({ tabs, newSource, paused, resumed,
+  selectTab, selectSource, loadSources }) {
   function onClickTab(e) {
-    selectTab({ tabActor: e.currentTarget.dataset.actorId })
-      .then(loadSources)
-      .then(() => {
-        gThreadClient.addListener("newSource", (event, packet) => {
-          newSource(packet.source);
-        });
-        gThreadClient.addListener("paused", (_, packet) => {
-          console.log(packet);
-        });
-      });
+    const tabActor = e.currentTarget.dataset.actorId;
+    debugTab({ tabActor, newSource, paused, resumed,
+               selectTab, selectSource, loadSources });
   }
 
   return dom.ul(

--- a/js/components/images/pause.svg
+++ b/js/components/images/pause.svg
@@ -1,0 +1,6 @@
+<svg width="10px" height="10px" viewBox="220 2 10 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 3.7.1 (28215) - http://www.bohemiancoding.com/sketch -->
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <polygon id="Polygon-1" stroke="#4A90E2" stroke-width="1" fill="#4A90E2" fill-rule="evenodd" transform="translate(225.937500, 6.765544) rotate(-270.000000) translate(-225.937500, -6.765544) " points="225.9375 3.70304446 229.703044 9.82804446 222.171956 9.82804446"></polygon>
+</svg>

--- a/js/components/images/resume.svg
+++ b/js/components/images/resume.svg
@@ -1,0 +1,6 @@
+<svg width="10px" height="10px" viewBox="94 1 10 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 3.7.1 (28215) - http://www.bohemiancoding.com/sketch -->
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <polygon id="Polygon-1" stroke="#4A90E2" stroke-width="1" fill="#4A90E2" fill-rule="evenodd" transform="translate(99.937500, 5.765544) rotate(-270.000000) translate(-99.937500, -5.765544) " points="99.9375 2.70304446 103.703044 8.82804446 96.1719555 8.82804446"></polygon>
+</svg>

--- a/js/components/images/stepIn.svg
+++ b/js/components/images/stepIn.svg
@@ -1,0 +1,13 @@
+
+<svg width="15px" height="13px" viewBox="768 531 15 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 3.7.1 (28215) - http://www.bohemiancoding.com/sketch -->
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Step-in" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(769.000000, 532.000000)">
+        <path d="M8.25949219,7.93368043 C8.13809758,7.97414531 8.00126613,7.96829969 7.87777151,7.90655238 L3.87777151,5.90655238 C3.63078226,5.78305776 3.53067009,5.48272124 3.65416471,5.23573199 C3.77765934,4.98874274 4.07799586,4.88863056 4.3249851,5.01212519 L7.87777151,6.78851839 L9.65416471,3.23573199 C9.77765934,2.98874274 10.0779959,2.88863056 10.3249851,3.01212519 C10.5719744,3.13561981 10.6720865,3.43595633 10.5485919,3.68294558 L8.5485919,7.68294558 C8.48684459,7.80644021 8.3808868,7.89321556 8.25949219,7.93368043 Z" id="Shape-Copy-2" stroke="#696969" stroke-width="0.5" fill="#696969" transform="translate(7.101378, 5.459339) rotate(18.000000) translate(-7.101378, -5.459339) "></path>
+        <path d="M0.5,9.625 L4.59458494,9.625" id="Line" stroke="#696969" stroke-width="1.25" stroke-linecap="round"></path>
+        <path d="M8.5,9.625 L12.5945849,9.625" id="Line-Copy-3" stroke="#696969" stroke-width="1.25" stroke-linecap="round"></path>
+        <path d="M7,8 L7,1" id="Line" stroke="#696969" stroke-width="1.5" stroke-linecap="round"></path>
+        <path d="M0.5,1 L6.5,1" id="Line-Copy-4" stroke="#696969" stroke-width="1.5" stroke-linecap="round"></path>
+    </g>
+</svg>

--- a/js/components/images/stepOut.svg
+++ b/js/components/images/stepOut.svg
@@ -1,0 +1,12 @@
+<svg width="14px" height="13px" viewBox="769 531 14 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 3.7.1 (28215) - http://www.bohemiancoding.com/sketch -->
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Step-out" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(776.000000, 537.500000) rotate(-90.000000) translate(-776.000000, -537.500000) translate(770.500000, 531.500000)">
+        <path d="M7.23872291,8.98092506 C7.1173283,9.02138993 6.98049685,9.01554432 6.85700223,8.95379701 L2.85700223,6.95379701 C2.61001298,6.83030238 2.50990081,6.52996586 2.63339543,6.28297662 C2.75689006,6.03598737 3.05722658,5.93587519 3.30421583,6.05936982 L6.85700223,7.83576302 L8.63339543,4.28297662 C8.75689006,4.03598737 9.05722658,3.93587519 9.30421583,4.05936982 C9.55120507,4.18286444 9.65131725,4.48320096 9.52782262,4.73019021 L7.52782262,8.73019021 C7.46607531,8.85368484 7.36011753,8.94046019 7.23872291,8.98092506 Z" id="Shape-Copy-2" stroke="#696969" stroke-width="0.5" fill="#696969" transform="translate(6.080609, 6.506583) rotate(18.000000) translate(-6.080609, -6.506583) "></path>
+        <path d="M1.97304034,10.625 L4.59458494,10.625" id="Line" stroke="#696969" stroke-width="1.25" stroke-linecap="round"></path>
+        <path d="M8.5,10.625 L11,10.625" id="Line-Copy-3" stroke="#696969" stroke-width="1.25" stroke-linecap="round"></path>
+        <path d="M6,8 L6,1" id="Line" stroke="#696969" stroke-width="1.5" stroke-linecap="round"></path>
+        <path d="M0.5,1 L6.5,1" id="Line-Copy-4" stroke="#696969" stroke-width="1.5" stroke-linecap="round"></path>
+    </g>
+</svg>

--- a/js/components/images/stepOver.svg
+++ b/js/components/images/stepOver.svg
@@ -1,0 +1,8 @@
+<svg width="15px" height="11px" viewBox="-1 -1 15 11" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 3.7.1 (28215) - http://www.bohemiancoding.com/sketch -->
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <path d="M10,5 C10,2.23857625 7.76142375,0 5,0 C2.23857625,0 0,2.23857625 0,5" id="Oval-1" stroke="#696969" stroke-width="1.5" stroke-linecap="round" fill="#FFFFFF" fill-rule="evenodd"></path>
+    <path d="M10.6582234,5.97445118 C10.5368288,6.01491605 10.3999974,6.00907044 10.2765027,5.94732312 L6.27650273,3.94732312 C6.02951348,3.8238285 5.92940131,3.52349198 6.05289593,3.27650273 C6.17639056,3.02951348 6.47672708,2.92940131 6.72371633,3.05289593 L10.2765027,4.82928914 L12.0528959,1.27650273 C12.1763906,1.02951348 12.4767271,0.929401308 12.7237163,1.05289593 C12.9707056,1.17639056 13.0708177,1.47672708 12.9473231,1.72371633 L10.9473231,5.72371633 C10.8855758,5.84721095 10.779618,5.93398631 10.6582234,5.97445118 Z" id="Shape" stroke="#696969" stroke-width="0.5" fill="#696969" fill-rule="evenodd"></path>
+    <circle id="Oval-1" stroke="#696969" stroke-width="1" fill="#696969" fill-rule="evenodd" cx="5" cy="8" r="1"></circle>
+</svg>

--- a/js/constants.js
+++ b/js/constants.js
@@ -26,3 +26,8 @@ exports.RELOAD = "RELOAD";
 
 exports.ADD_TABS = "ADD_TABS";
 exports.SELECT_TAB = "SELECT_TAB";
+
+exports.BREAK_ON_NEXT = "BREAK_ON_NEXT";
+exports.RESUME = "RESUME";
+exports.PAUSED = "PAUSED";
+exports.COMMAND = "COMMAND";

--- a/js/lib/codemirror.css
+++ b/js/lib/codemirror.css
@@ -1,3 +1,4 @@
+
 .theme-body {
   background: var(--theme-body-background);
   color: var(--theme-body-color);

--- a/js/lib/variables.css
+++ b/js/lib/variables.css
@@ -57,4 +57,6 @@
   --theme-graphs-grey: #cccccc;
   --theme-graphs-full-red: #f00;
   --theme-graphs-full-blue: #00f;
+
+  --breakpoint-active-color: rgba(44,187,15,.1);
 }

--- a/js/queries.js
+++ b/js/queries.js
@@ -29,6 +29,10 @@ function getSelectedTab(state) {
   return state.tabs.get("selectedTab");
 }
 
+function getPause(state) {
+  return state.pause.get("pause");
+}
+
 /* Queries */
 function getSource(state, actor) {
   return getSources(state).get(actor);
@@ -54,6 +58,15 @@ function getBreakpoint(state, location) {
   return getBreakpoints(state).get(makeLocationId(location));
 }
 
+function getBreakpointByActor(state) {
+  return getBreakpoints(state).valueSeq()
+    .groupBy(bp => bp.getIn(["location", "actor"]));
+}
+
+function getBreakpointsForSource(state, actor) {
+  return getBreakpointByActor(state).get(actor);
+}
+
 /**
  * @param object - location
  */
@@ -72,7 +85,9 @@ module.exports = {
   getSourceText,
   getBreakpoint,
   getBreakpoints,
+  getBreakpointsForSource,
   getTabs,
   getSelectedTab,
+  getPause,
   makeLocationId
 };

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -8,11 +8,13 @@ const sources = require("./sources");
 const breakpoints = require("./breakpoints");
 const asyncRequests = require("./async-requests");
 const tabs = require("./tabs");
+const pause = require("./pause");
 
 module.exports = {
   eventListeners,
   sources,
   breakpoints,
   asyncRequests,
-  tabs
+  tabs,
+  pause
 };

--- a/js/reducers/pause.js
+++ b/js/reducers/pause.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+const constants = require("../constants");
+const { fromJS } = require("immutable");
+
+const initialState = fromJS({
+  pause: null,
+  breakOnNext: false
+});
+
+function update(state = initialState, action, emit) {
+  switch (action.type) {
+    case constants.PAUSED:
+      return state.set("pause", fromJS(action.value));
+    case constants.RESUME:
+      return state.set("pause", null);
+    case constants.BREAK_ON_NEXT:
+      return state.set(["breakOnNext"], true);
+  }
+
+  return state;
+}
+
+module.exports = update;

--- a/js/util/editor.js
+++ b/js/util/editor.js
@@ -1,0 +1,49 @@
+"use strict";
+
+// Maximum allowed margin (in number of lines) from top or bottom of the editor
+// while shifting to a line which was initially out of view.
+const MAX_VERTICAL_OFFSET = 3;
+
+/**
+ * Aligns the provided line to either "top", "center" or "bottom" of the
+ * editor view with a maximum margin of MAX_VERTICAL_OFFSET lines from top or
+ * bottom.
+ */
+function alignLine(cm, line, align = "top") {
+  let from = cm.lineAtHeight(0, "page");
+  let to = cm.lineAtHeight(cm.getWrapperElement().clientHeight, "page");
+  let linesVisible = to - from;
+  let halfVisible = Math.round(linesVisible / 2);
+
+  // If the target line is in view, skip the vertical alignment part.
+  if (line <= to && line >= from) {
+    return;
+  }
+
+  // Setting the offset so that the line always falls in the upper half
+  // of visible lines (lower half for bottom aligned).
+  // MAX_VERTICAL_OFFSET is the maximum allowed value.
+  let offset = Math.min(halfVisible, MAX_VERTICAL_OFFSET);
+
+  let topLine = {
+    "center": Math.max(line - halfVisible, 0),
+    "bottom": Math.max(line - linesVisible + offset, 0),
+    "top": Math.max(line - offset, 0)
+  }[align || "top"] || offset;
+
+  // Bringing down the topLine to total lines in the editor if exceeding.
+  topLine = Math.min(topLine, cm.lineCount());
+  setFirstVisibleLine(cm, topLine);
+}
+
+/**
+ * Scrolls the view such that the given line number is the first visible line.
+ */
+function setFirstVisibleLine(cm, line) {
+  let { top } = cm.charCoords({line: line, ch: 0}, "local");
+  cm.scrollTo(0, top);
+}
+
+module.exports = {
+  alignLine
+};


### PR DESCRIPTION
Features:

* Commands
  * Resume / Pause
  * Step Over, Step In, Step Up
  * Some pixel (im)perfect icons
* on pause
  * updates source
  * scrolls to and highlights debug line
  * shows breakpoints
* Right Sidebar
  * has a top action bar
  * has a call stack and scopes pane
  * breakpoints shows "no breakpoints"

Implementation

* Redux
  * new pause action and reducer
  * pause / resume actions for responding to server events
  * command / breakOnNext action for debugger actions
* Editor
  * better source text updating
  * breakpoint gutter markers are added on the props update lifecycle
  * stateless editor utility for bits of functionality like (alignLine)
* debugTab
  * extracted the logic in main/Tabs for debugging a tab
  * sets up the client listeners for paused/resumed
  * added unsolicited event logging as a sanity measure


[demo](https://www.dropbox.com/s/17sh3xi5iwjyqpn/debugger-screen.mov?dl=0)