### PR TITLE
Start simple node express server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "debugger.html",
   "scripts": {
-    "start": "firefox-proxy & ./node_modules/.bin/webpack --watch & ./node_modules/.bin/static --port 8000",
+    "start": "firefox-proxy & node server",
     "lint-css": "stylelint js/components/*.css",
     "lint-js": "eslint js",
     "test": "./bin/test-node js/actions/tests",
@@ -15,13 +15,13 @@
     "chai": "^3.5.0",
     "co": "=4.6.0",
     "codemirror": "^5.1.0",
+    "express": "^4.13.4",
     "ff-devtools-libs": "^0.1.1",
     "immutable": "^3.7.6",
     "json-loader": "^0.5.4",
     "karma": "^0.13.22",
     "mocha": "^2.4.5",
     "net": "^1.0.2",
-    "node-static": "^0.7.7",
     "react": "=0.14.7",
     "react-dom": "=0.14.7",
     "react-immutable-proptypes": "^1.7.1",
@@ -31,6 +31,7 @@
     "seamless-immutable": "=5.1.1",
     "stylelint": "^5.3.0",
     "webpack": "=1.12.14",
+    "webpack-dev-middleware": "^1.6.1",
     "ws": "^1.0.1"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const path = require("path");
+const webpack = require("webpack");
+const express = require("express");
+const config = require("./webpack.config");
+const webpackDevMiddleware = require("webpack-dev-middleware");
+
+const app = express();
+const compiler = webpack(config);
+
+app.use("/js", express.static("js"));
+
+app.use(webpackDevMiddleware(compiler, {
+  publicPath: "/build",
+  noInfo: true,
+  stats: {
+    colors: true
+  }
+}));
+
+app.get("/", function(req, res) {
+  res.sendFile(path.join(__dirname, "index.html"));
+});
+
+app.listen(8000, "localhost", function(err, result) {
+  if (err) {
+    console.log(err);
+  }
+
+  console.log("Listening at localhost:8000");
+});


### PR DESCRIPTION
+ uses webpack-dev-middleware
+ replaces starting node serve-static
+ eventually we can add other niceties here (cache busting, hmr, ...)

Benefits of webpack-dev-middleware:
+ doesn't write to file
+ on refresh, will hold the request if there isn't a build ready