### PR TITLE
Move Karma tests to circle-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,8 @@ node_js:
 install:
   - npm install
 before_install:
-  - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 script:
   - npm run lint-css
   - npm run lint-js
-  - npm run test
-  - npm run test-karma
-addons:
-  firefox: latest

--- a/bin/test-node
+++ b/bin/test-node
@@ -3,7 +3,7 @@
 
 const fs = require("fs");
 const webpack = require("webpack");
-const join = require("path").join
+const join = require("path").join;
 const resolve = require("path").resolve;
 const rimraf = require("rimraf");
 const projectWebpackConfig = require("../webpack.config");
@@ -13,7 +13,7 @@ const BUILD_DIR = join(__dirname, "../build");
 
 function getTestPaths(paths) {
   return paths.reduce((acc, path) => {
-    if(fs.statSync(path).isDirectory()) {
+    if (fs.statSync(path).isDirectory()) {
       const files = fs.readdirSync(path);
       return acc.concat.apply(
         acc,

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,13 @@
+test:
+  post:
+    - npm run test
+    - npm run test-karma
+dependencies:
+  override:
+    - curl -L -o google-chrome.deb https://s3.amazonaws.com/circle-downloads/google-chrome-stable_current_amd64_47.0.2526.73-1.deb
+    - sudo dpkg -i google-chrome.deb
+    - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
+    - rm google-chrome.deb
+machine:
+  node:
+    version: 5.10.1

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = function(config) {
-  let configuration = {
+  const configuration = {
     basePath: "",
     frameworks: ["mocha"],
     files: [
@@ -11,24 +11,14 @@ module.exports = function(config) {
     exclude: [],
     preprocessors: {},
     reporters: ["progress"],
+    browsers: ["Firefox", "Chrome"],
     port: 8002,
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: false,
-    customLaunchers: {
-      Chrome_travis_ci: {
-        base: "Chrome",
-        flags: ["--no-sandbox"]
-      }
-    },
     singleRun: false,
     concurrency: Infinity
   };
 
-  if (process.env.TRAVIS) {
-    configuration.browsers = ["Chrome_travis_ci", "Firefox"];
-  } else {
-    config.browsers = ["Firefox", "Chrome"];
-  }
   config.set(configuration);
 };


### PR DESCRIPTION
Moves the Karma tests out of Travis and into Circle Ci. There are two benefits with the move:
1) the tests are run with an up to date version of chrome
2) the slower karma tests are run in along side the faster tests, which hopefully will keep our tests faster.

Signing up for circle ci is as easy as going to (https://circleci.com/) and enabling debugger.html