### PR TITLE
Fix Chrome's Codemirror Editor layout

### DIFF
--- a/js/components/Editor.css
+++ b/js/components/Editor.css
@@ -4,8 +4,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.editor {
+/**
+ * There's a known codemirror flex issue with chrome that this addresses.
+ * BUG https://github.com/jlongster/debugger.html/issues/63
+ */
+.editor-container {
+  display: flex;
+  position: relative;
   flex: 1;
+}
+
+.editor {
+  position: absolute;
+  height: 100%;
+  width: 100%;
 }
 
 .editor.breakpoint {

--- a/js/components/Editor.js
+++ b/js/components/Editor.js
@@ -124,12 +124,13 @@ const Editor = React.createClass({
 
   render() {
     return (
-      dom.div(
-        { className: "editor" },
-        dom.textarea({
-          ref: "editor",
-          defaultValue: "..."
-        })
+      dom.div({ className: "editor-container" },
+          dom.div({ className: "editor" },
+          dom.textarea({
+            ref: "editor",
+            defaultValue: "..."
+          })
+        )
       )
     );
   }


### PR DESCRIPTION
Addresses https://github.com/jlongster/debugger.html/issues/63

The problem is that codemirror's parent is a flexbox element and
codemirror can't reliably calcuate it's height and width.

The *fix* is:
+ grandparent: flexbox, position relative
+ parent: position absolute, width and height 100%