### PR TITLE
Add breakpoint styling

### DIFF
--- a/js/components/Editor.css
+++ b/js/components/Editor.css
@@ -25,6 +25,16 @@
   font-family: Menlo, monospace !important;
 }
 
+/* set the linenumber white when there is a breakpoint */
+.breakpoint .CodeMirror-linenumber {
+  color: white;
+}
+
+/* move the breakpoint below the linenumber */
+.breakpoint .CodeMirror-gutter-elt:last-child {
+  z-index: 0;
+}
+
 .debug-line .CodeMirror-line {
   background-color: var(--breakpoint-active-color) !important;
 }

--- a/js/components/Editor.js
+++ b/js/components/Editor.js
@@ -47,6 +47,7 @@ const _Breakpoint = React.createClass({
     const line = bp.getIn(["location", "line"]) - 1;
 
     this.props.editor.setGutterMarker(line, "breakpoints", makeMarker());
+    this.props.editor.addLineClass(line, "line", "breakpoint");
   },
 
   componentWillUnmount: function() {
@@ -54,6 +55,7 @@ const _Breakpoint = React.createClass({
     const line = bp.getIn(["location", "line"]) - 1;
 
     this.props.editor.setGutterMarker(line, "breakpoints", null);
+    this.props.editor.removeLineClass(line, "line", "breakpoint");
   },
 
   render: function() {


### PR DESCRIPTION
This sets the line number font to white and moves the breakpoint below
the linenumber.

I couldn't find where Firefox did that work, so I thought I'd share the
PR incase there's a better way of doing it. One thing I noticed for
example, is if the breakpoint appears ahead in the DOM structure, then
it doesn't need any z-index treatment.