### PR TITLE
(WIP) Test watcher

### DIFF
--- a/bin/test-node
+++ b/bin/test-node
@@ -8,8 +8,10 @@ const resolve = require("path").resolve;
 const rimraf = require("rimraf");
 const projectWebpackConfig = require("../webpack.config");
 const Mocha = require("mocha");
+const program = require("commander");
 
 const BUILD_DIR = join(__dirname, "../build");
+const JS_DIR = join(__dirname, "../js");
 
 function getTestPaths(paths) {
   return paths.reduce((acc, path) => {
@@ -17,20 +19,19 @@ function getTestPaths(paths) {
       const files = fs.readdirSync(path);
       return acc.concat.apply(
         acc,
-        files.filter(p => p[0] !== '.').map(file => join(path, file))
+        files.filter(p => p[0] !== ".").map(file => join(path, file))
       );
     }
-    else {
-      if(path[0] !== '.') {
-        return acc.concat([path]);
-      }
-      return acc;
+
+    if (path[0] !== ".") {
+      return acc.concat([path]);
     }
+
+    return acc;
   }, []);
 }
 
 function setupWebpackConfig(webpackConfig, testPaths) {
-
   return Object.assign({}, webpackConfig, {
     entry: ["babel-polyfill"].concat(testPaths.map((path) => resolve(path))),
 
@@ -43,12 +44,13 @@ function setupWebpackConfig(webpackConfig, testPaths) {
       loaders: [
         {
           test: /.js$/,
-          loader: 'babel-loader',
+          loader: "babel-loader",
           exclude: (path) => {
-            return path.includes("node_modules") && !path.includes("ff-devtools-libs")
+            return path.includes("node_modules")
+              && !path.includes("ff-devtools-libs");
           },
           query: {
-            presets: ['es2015', 'stage-0']
+            presets: ["es2015", "stage-0"]
           }
         }
       ]
@@ -60,8 +62,9 @@ function setupWebpackConfig(webpackConfig, testPaths) {
 function runMocha() {
   mocha.addFile(join(BUILD_DIR, "test-bundle.js"));
 
-  mocha.run(function(failures){
-    process.on('exit', function () {
+  mocha.run(function(failures) {
+    isRunning = false;
+    process.on("exit", function() {
       process.exit(failures);
     });
   });
@@ -70,9 +73,9 @@ function runMocha() {
 function runWebpack(beforeBuild, afterBuild) {
   beforeBuild();
   webpack(webpackConfig).run((err, stats) => {
-    if(err) {
+    if (err) {
       console.log("ERROR", err);
-    } else if(stats.compilation.errors.length) {
+    } else if (stats.compilation.errors.length) {
       console.log(stats.toString({ colors: true }));
     } else {
       afterBuild();
@@ -80,12 +83,36 @@ function runWebpack(beforeBuild, afterBuild) {
   });
 }
 
-const paths = process.argv.slice(2);
+function runTest() {
+  runWebpack(
+    () => rimraf.sync(join(BUILD_DIR, "test-bundle.js")),
+    () => runMocha()
+  );
+}
+
+program
+  .usage("[options] <file ...>")
+  .option("-w, --watch ", "Watch for changes")
+  .parse(process.argv);
+
+const paths = program.args;
+const shouldWatch = !!program.watch;
 const mocha = new Mocha();
 const testPaths = getTestPaths(paths);
 const webpackConfig = setupWebpackConfig(projectWebpackConfig, testPaths);
 
-runWebpack(
-  () => rimraf.sync(join(__dirname, '../build/tests')),
-  () => runMocha()
-);
+let isRunning = true;
+runTest();
+
+if (shouldWatch) {
+  fs.watch(JS_DIR, {recursive: true}, (event, filename) => {
+    if (!filename || isRunning) {
+      return;
+    }
+
+    console.log(`File: ${filename} - ${event}`);
+    console.log("Running tests!");
+    isRunning = true;
+    runTest();
+  });
+}

--- a/js/actions/tests/loadSourceText.js
+++ b/js/actions/tests/loadSourceText.js
@@ -23,8 +23,9 @@ const mockThreadClient = {
   }
 };
 
-describe("loadSourceText", () => {
+describe("loadSourceText", function() {
   beforeEach(function() {
+    console.log("beforeEach");
     this.store = createStore(mockThreadClient);
   });
 
@@ -35,7 +36,8 @@ describe("loadSourceText", () => {
     });
 
     it("Store has the source text", function() {
-      const fooSourceText = queries.getSourceText(this.store.getState(), "foo1");
+      const fooSourceText = queries.getSourceText(
+                              this.store.getState(), "foo1");
       expect(fooSourceText.get("text")).to.equal(sourceText.foo1.source);
     });
   });

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "co": "=4.6.0",
     "codemirror": "^5.1.0",
+    "commander": "^2.9.0",
     "expect.js": "^0.3.1",
     "express": "^4.13.4",
     "ff-devtools-libs": "^0.1.1",


### PR DESCRIPTION
I took a stab at adding a test watcher for node.

Most of the diff is linting test-node. Notable changes are:
+ commander for parsing arguments
+ fs.watch for watching for changes

Here is the [error](https://gist.github.com/jasonLaster/e1eded70e37820c5a9ca50348b8e6c53) I'm seeing. I didn't spend too long debugging it, but it looks like an issue with ff-devtools-libs, where these two shams are not being requested the second time:

```
Cc sham for @mozilla.org/io-util;1
CC sham for @mozilla.org/scriptableinputstream;1 nsIScriptableInputStream init
```

I double checked that the build file is updated and I'm pretty sure babelified.