### PR TITLE
Add Storybook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const { configure } = require("@kadira/storybook");
+require("../build/styles.css");
+
+function loadStories() {
+  require("../js/components/stories");
+}
+
+configure(loadStories, module);

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const path = require("path");
+
+module.exports = {
+  resolve: {
+    alias: {
+      "devtools": "ff-devtools-libs",
+      "sdk": "ff-devtools-libs/sdk"
+    },
+    extensions: ["", ".js", ".jsm"],
+    root: path.join(__dirname, "node_modules")
+  },
+  module: {
+    loaders: [
+      { test: /\.css$/, loader: "style-loader!css-loader" }
+    ]
+  }
+};

--- a/js/components/stories/Breakpoints.js
+++ b/js/components/stories/Breakpoints.js
@@ -1,0 +1,99 @@
+"use strict";
+
+const React = require("react");
+const { DOM: dom, createElement } = React;
+const { storiesOf } = require("@kadira/storybook");
+const configureStore = require("../../create-store");
+const { combineReducers } = require("redux");
+const reducers = require("../../reducers");
+const { Provider } = require("react-redux");
+const { fromJS } = require("immutable");
+
+const Breakpoints = React.createFactory(require("../Breakpoints"));
+
+const fixtures = {
+  sources: {
+    "fooSourceActor": {
+      actor: "fooSourceActor",
+      url: "http://example.com/foo.js"
+    },
+    "barSourceActor": {
+      actor: "barSourceActor",
+      url: "http://example.com/bar.js"
+    }
+  },
+  breakpoints: {
+    "fooBreakpointActor": {
+      actor: "fooBreakpointActor",
+      location: {
+        actor: "fooSourceActor",
+        line: 16
+      },
+    },
+    "barBreakpointActor": {
+      actor: "barBreakpointActor",
+      location: {
+        actor: "barSourceActor",
+        line: 18
+      },
+    }
+  }
+};
+
+storiesOf("Breakpoints", module)
+  .add("No Breakpoints", () => {
+    const store = configureStore({})(combineReducers(reducers), {
+      sources: fromJS({
+        sources: {}
+      }),
+      breakpoints: fromJS({
+        breakpoints: {}
+      })
+    });
+    return renderBreakpoints(store);
+  })
+  .add("1 Domain", () => {
+    const store = configureStore({})(combineReducers(reducers), {
+      sources: fromJS({
+        sources: {
+          "fooSourceActor": fixtures.sources.fooSourceActor,
+        }
+      }),
+      breakpoints: fromJS({
+        breakpoints: {
+          "fooBreakpointActor": fixtures.breakpoints.fooBreakpointActor,
+        }
+      })
+    });
+    return renderBreakpoints(store);
+  })
+  .add("2 Domains", () => {
+    const store = configureStore({})(combineReducers(reducers), {
+      sources: fromJS({
+        sources: {
+          "fooSourceActor": fixtures.sources.fooSourceActor,
+          "barSourceActor": fixtures.sources.barSourceActor,
+        }
+      }),
+      breakpoints: fromJS({
+        breakpoints: {
+          "fooBreakpointActor": fixtures.breakpoints.fooBreakpointActor,
+          "barBreakpointActor": fixtures.breakpoints.barBreakpointActor,
+        }
+      })
+    });
+    return renderBreakpoints(store);
+  });
+
+function renderBreakpoints(store) {
+  return dom.div({style:
+    {
+      width: "300px",
+      margin: "auto",
+      paddingTop: "100px",
+    }},
+    dom.div({style: {border: "1px solid #ccc", padding: "20px" }},
+      createElement(Provider, { store }, Breakpoints())
+    )
+  );
+}

--- a/js/components/stories/SplitBox.js
+++ b/js/components/stories/SplitBox.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const React = require("react");
+const { DOM: dom } = React;
+const { storiesOf } = require("@kadira/storybook");
+
+storiesOf("SplitBox", module)
+  .add("Default", () => {})
+  .add("Left Initial Width", () => {})
+  .add("Flex Right Panel", () => {});

--- a/js/components/stories/accordion.js
+++ b/js/components/stories/accordion.js
@@ -1,0 +1,44 @@
+"use strict";
+
+const React = require("react");
+const { DOM: dom } = React;
+const Accordion = React.createFactory(require("../Accordion"));
+const { storiesOf } = require("@kadira/storybook");
+
+let items = [
+  { header: "Breakpoints",
+    component: () => dom.div({className: "pane-info"}, "No Breakpoints")
+  },
+  { header: "Call Stack",
+    component: () => dom.div({className: "pane-info"}, "Not Paused")
+  },
+  { header: "Scopes",
+    component: () => dom.div({className: "pane-info"}, "Not Paused")
+  }
+];
+
+storiesOf("Accordion", module)
+  .add("3 Closed Panes", () => {
+    items[1].opened = false;
+    return renderContainer(
+      Accordion({
+        items: items
+      })
+    );
+  })
+  .add("1 Open Pane", () => {
+    items[1].opened = true;
+    return renderContainer(
+      Accordion({
+        items: items
+      })
+    );
+  });
+
+function renderContainer(child) {
+  return dom.div({ style: {
+    width: "300px",
+    margin: "auto",
+    paddingTop: "100px"
+  }}, child);
+}

--- a/js/components/stories/editor.js
+++ b/js/components/stories/editor.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const React = require("react");
+const { DOM: dom } = React;
+// const Accordion = React.createFactory(require("../Accordion"));
+const { storiesOf } = require("@kadira/storybook");
+
+storiesOf("Editor", module)
+  .add("Loading", () => {})
+  .add("Loaded Source", () => {})
+  .add("With a breakpoint", () => {});

--- a/js/components/stories/index.js
+++ b/js/components/stories/index.js
@@ -1,0 +1,6 @@
+"use strict";
+
+require("./accordion");
+require("./Breakpoints");
+require("./editor");
+require("./SplitBox");

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "lint-js": "eslint js",
     "test": "./bin/test-node js/actions/tests",
     "test-browser": "./bin/test-browser js/actions/tests",
-    "test-karma": "./node_modules/.bin/karma start --single-run"
+    "test-karma": "./node_modules/.bin/karma start --single-run",
+    "storybook": "start-storybook -p 9001 -s js"
   },
   "dependencies": {
     "babel-cli": "^6.7.5",
@@ -35,6 +36,7 @@
     "ws": "^1.0.1"
   },
   "devDependencies": {
+    "@kadira/storybook": "^1.17.1",
     "babel": "^6.5.2",
     "babel-core": "^6.7.6",
     "babel-loader": "^6.2.4",


### PR DESCRIPTION
Storybook is an environment for documenting / iterating on the components in our App. It has many of the benefits of our unit tests, but with a product bias.

This patch adds:
+ storybook config
+ some storybook "stories" for the accordion and breakpoints

My hope is that we can experiment with this style of development / documentation and see if it works for us. Also, maybe utilize it for some component unit tests as well.

![storybook](https://cloud.githubusercontent.com/assets/254562/14788691/210077e8-0ad7-11e6-869b-08e0ec0601bb.png)
