### PR TITLE
Add Query Presenters

### DIFF
--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -66,7 +66,7 @@ const Breakpoint = React.createFactory(_Breakpoint);
 
 const Editor = React.createClass({
   propTypes: {
-    breakpoints: ImPropTypes.list,
+    breakpoints: ImPropTypes.map.isRequired,
     selectedSource: PropTypes.object,
     sourceText: PropTypes.object,
     addBreakpoint: PropTypes.func,

--- a/public/js/reducers/pause.js
+++ b/public/js/reducers/pause.js
@@ -14,7 +14,13 @@ const initialState = fromJS({
 function update(state = initialState, action, emit) {
   switch (action.type) {
     case constants.PAUSED:
-      return state.set("pause", fromJS(action.value));
+      const pause = action.value;
+      pause.isInterrupted = pause.why.type == "interrupted";
+      if (!pause.isInterrupted) {
+        pause.frame.where.actor = pause.frame.where.source.actor;
+      }
+
+      return state.set("pause", fromJS(pause));
     case constants.RESUME:
       return state.set("pause", null);
     case constants.BREAK_ON_NEXT:

--- a/public/js/reducers/sources.js
+++ b/public/js/reducers/sources.js
@@ -16,7 +16,9 @@ const initialState = fromJS({
 function update(state = initialState, action) {
   switch (action.type) {
     case constants.ADD_SOURCE:
-      return state.mergeIn(["sources", action.source.actor], action.source);
+      let newSource = action.source;
+      newSource.filename = getFilenameFromUrl(newSource.url);
+      return state.mergeIn(["sources", action.source.actor], newSource);
 
     case constants.LOAD_SOURCES:
       if (action.status === "done") {
@@ -28,6 +30,7 @@ function update(state = initialState, action) {
         return state.mergeIn(
           ["sources"],
           fromJS(sources.map(source => {
+            source.filename = getFilenameFromUrl(source.url);
             return [source.actor, source];
           }))
         );
@@ -76,6 +79,15 @@ function update(state = initialState, action) {
   }
 
   return state;
+}
+
+function getFilenameFromUrl(sourceUrl) {
+  if (!sourceUrl) {
+    return "";
+  }
+
+  const url = new URL(sourceUrl);
+  return url.pathname.substring(url.pathname.lastIndexOf("/") + 1);
 }
 
 function _updateText(state, action) {

--- a/public/js/selectors.js
+++ b/public/js/selectors.js
@@ -64,6 +64,19 @@ function getSourceText(state, actor) {
   return getSourcesText(state).get(actor);
 }
 
+function isCurrentlyPausedAtBreakpoint(state, breakpoint) {
+  const pause = getPause(state);
+
+  if (!pause || pause.get("isInterrupted")) {
+    return false;
+  }
+
+  const breakpointLocation = makeLocationId(breakpoint.get("location").toJS());
+  const pauseLocation = makeLocationId(pause.getIn(["frame", "where"]).toJS());
+
+  return breakpointLocation == pauseLocation;
+}
+
 /**
  * @param object - location
  */
@@ -86,5 +99,6 @@ module.exports = {
   getTabs,
   getSelectedTab,
   getPause,
-  makeLocationId
+  makeLocationId,
+  isCurrentlyPausedAtBreakpoint
 };


### PR DESCRIPTION
Our queries up to this point have focused on data access. For example, get a source by source actor or get a breakpoint by location.

There are three limitations here:

1) Inconsistency

+ The pause state has a `frame.where.source` property and the breakpoint state has a `location.actor` property. This PR adds a pause `frame.where.actor` property and a breakpoint `location.source` property. The two states are now consistent.

2) Incomplete

+ The breakpoint state has a `location.actor` property, but does not have a `frame.where.source` property. This is a problem because when a breakpoint is shown in the breakpoint list, its source is needed.
+ The source state has a `url` property, but does not have a `filename` property, which would be helpful when showing a breakpoint.

3) Performance

+ Because each component is managing it's own data access / presentation, it is harder to memoize without setting intermediate component state. By moving the presentation logic to the queries, we can use tools like re-select to cache the computed properties and denormalized state.

Generalizations:

+ Computed Properties: queries should be responsible for formatting and computing derived properties
+ Actor denormalization: if a query has an actor field, it should denormalize the state. i.e. the breakpoint has a `location.actor` field and should add a `location.source` field.  

Presenters:

Data access and data presentation are fundamentally different problems. With that in mind, I added separate presentBreakpoint, presentSource functions that the queries use to return presented data. 

Will this conflict with your breakpoint work? Yes! but that's okay.