### PR TITLE
SelectSource Tests + Refactoring

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -13,7 +13,8 @@ module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.css$/, loader: "style-loader!css-loader" }
+      { test: /\.css$/, loader: "style-loader!css-loader" },
+      { test: /\.json$/, loader: "json-loader" },
     ]
   }
 };

--- a/bin/test-node
+++ b/bin/test-node
@@ -31,6 +31,10 @@ function setupWebpackConfig(webpackConfig, testPaths) {
           query: {
             presets: ["es2015", "stage-0"]
           }
+        },
+        {
+          test: /\.json$/,
+          loader: "json-loader"
         }
       ]
     },

--- a/public/js/actions/tests/newSource.js
+++ b/public/js/actions/tests/newSource.js
@@ -1,29 +1,22 @@
 "use strict";
 
 const { actions, queries, createStore } = require("../../util/test-head");
+const fixtures = require("../../test/fixtures.json");
+const { newSource } = actions;
+const { getSourceByActor } = queries;
+const sourcesFixtures = fixtures.sources.sources;
 
 const store = createStore();
 const expect = require("expect.js");
 
 describe("newSource", () => {
-  describe("adding two sources", () => {
-    beforeEach(() => {
-      store.dispatch(actions.newSource({
-        url: "http://example.com/foo1.js",
-        actor: "foo1"
-      }));
-      store.dispatch(actions.newSource({
-        url: "http://example.com/foo2.js",
-        actor: "foo2"
-      }));
-    });
+  it("adding two sources", () => {
+    store.dispatch(newSource(sourcesFixtures.fooSourceActor));
+    store.dispatch(newSource(sourcesFixtures.barSourceActor));
+    const foo = getSourceByActor(store.getState(), "fooSourceActor");
+    const bar = getSourceByActor(store.getState(), "barSourceActor");
 
-    it("can get source by actor", () => {
-      const foo1 = queries.getSourceByActor(store.getState(), "foo1");
-      const foo2 = queries.getSourceByActor(store.getState(), "foo2");
-
-      expect(foo1.get("actor")).to.equal("foo1");
-      expect(foo2.get("actor")).to.equal("foo2");
-    });
+    expect(foo.get("actor")).to.equal("fooSourceActor");
+    expect(bar.get("actor")).to.equal("barSourceActor");
   });
 });

--- a/public/js/actions/tests/selectSource.js
+++ b/public/js/actions/tests/selectSource.js
@@ -1,12 +1,13 @@
 "use strict";
 
 const { actions, queries, createStore } = require("../../util/test-head");
+const fixtures = require("../../test/fixtures.json");
+const { fromJS } = require("immutable");
+const expect = require("expect.js");
+
 const { getSelectedSource } = queries;
 const { selectSource } = actions;
-
-const { fromJS } = require("immutable");
-
-const expect = require("expect.js");
+const sourcesFixtures = fixtures.sources;
 
 const simpleMockThreadClient = {
   source: function(form) {
@@ -17,25 +18,6 @@ const simpleMockThreadClient = {
         });
       }
     };
-  }
-};
-
-const sourcesFixtures = {
-  sources: {
-    "fooSourceActor": {
-      actor: "fooSourceActor",
-      url: "http://example.com/foo.js"
-    },
-    "barSourceActor": {
-      actor: "barSourceActor",
-      url: "http://example.com/bar.js"
-    }
-  },
-  sourcesText: {
-    "fooSourceActor": {
-      contentType: "text/javascript",
-      text: "function() {\n  return 5;\n}",
-    }
   }
 };
 

--- a/public/js/actions/tests/selectSource.js
+++ b/public/js/actions/tests/selectSource.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const { actions, queries, createStore } = require("../../util/test-head");
+const { getSelectedSource } = queries;
+const { selectSource } = actions;
+
+const { fromJS } = require("immutable");
+
+const expect = require("expect.js");
+
+const simpleMockThreadClient = {
+  source: function(form) {
+    return {
+      source: () => {
+        return new Promise((resolve, reject) => {
+          resolve(sourcesFixtures.sources[form.actor]);
+        });
+      }
+    };
+  }
+};
+
+const sourcesFixtures = {
+  sources: {
+    "fooSourceActor": {
+      actor: "fooSourceActor",
+      url: "http://example.com/foo.js"
+    },
+    "barSourceActor": {
+      actor: "barSourceActor",
+      url: "http://example.com/bar.js"
+    }
+  },
+  sourcesText: {
+    "fooSourceActor": {
+      contentType: "text/javascript",
+      text: "function() {\n  return 5;\n}",
+    }
+  }
+};
+
+describe("selectSource", () => {
+  it("selecting an already loaded source", function() {
+    const initialState = {
+      sources: fromJS({
+        sources: {
+          "fooSourceActor": sourcesFixtures.sources.fooSourceActor
+        },
+        sourcesText: {
+          "fooSourceActor": sourcesFixtures.sourcesText.fooSourceActor
+        }
+      })
+    };
+
+    this.store = createStore({}, initialState);
+    this.store.dispatch(selectSource(sourcesFixtures.sources.fooSourceActor));
+
+    const fooSourceText = getSelectedSource(this.store.getState());
+    expect(fooSourceText.get("actor")).to.equal("fooSourceActor");
+  });
+
+  it("selecting a source that hasn\'t been loaded", function() {
+    const initialState = {
+      sources: fromJS({
+        sources: {
+          "fooSourceActor": sourcesFixtures.sources.fooSourceActor
+        },
+        sourcesText: {}
+      })
+    };
+
+    this.store = createStore(simpleMockThreadClient, initialState);
+    this.store.dispatch(selectSource(sourcesFixtures.sources.fooSourceActor));
+
+    const fooSourceText = getSelectedSource(this.store.getState());
+    expect(fooSourceText.get("actor")).to.equal("fooSourceActor");
+  });
+});

--- a/public/js/components/stories/Breakpoints.js
+++ b/public/js/components/stories/Breakpoints.js
@@ -10,35 +10,7 @@ const { Provider } = require("react-redux");
 const { fromJS } = require("immutable");
 
 const Breakpoints = React.createFactory(require("../Breakpoints"));
-
-const fixtures = {
-  sources: {
-    "fooSourceActor": {
-      actor: "fooSourceActor",
-      url: "http://example.com/foo.js"
-    },
-    "barSourceActor": {
-      actor: "barSourceActor",
-      url: "http://example.com/bar.js"
-    }
-  },
-  breakpoints: {
-    "fooBreakpointActor": {
-      actor: "fooBreakpointActor",
-      location: {
-        actor: "fooSourceActor",
-        line: 16
-      },
-    },
-    "barBreakpointActor": {
-      actor: "barBreakpointActor",
-      location: {
-        actor: "barSourceActor",
-        line: 18
-      },
-    }
-  }
-};
+const fixtures = require("../../test/fixtures.json");
 
 storiesOf("Breakpoints", module)
   .add("No Breakpoints", () => {

--- a/public/js/test/fixtures.json
+++ b/public/js/test/fixtures.json
@@ -1,0 +1,36 @@
+{
+  "sources": {
+    "sources": {
+      "fooSourceActor": {
+        "actor": "fooSourceActor",
+        "url": "http://example.com/foo.js"
+      },
+      "barSourceActor": {
+        "actor": "barSourceActor",
+        "url": "http://example.com/bar.js"
+      }
+    },
+    "sourcesText": {
+      "fooSourceActor": {
+        "contentType": "text/javascript",
+        "text": "function() {\n  return 5;\n}"
+      }
+    }
+  },
+  "breakpoints": {
+    "fooBreakpointActor": {
+      "actor": "fooBreakpointActor",
+      "location": {
+        "actor": "fooSourceActor",
+        "line": 16
+      }
+    },
+    "barBreakpointActor": {
+      "actor": "barBreakpointActor",
+      "location": {
+        "actor": "barSourceActor",
+        "line": 18
+      }
+    }
+  }
+}

--- a/public/js/util/test-head.js
+++ b/public/js/util/test-head.js
@@ -7,13 +7,13 @@ const queries = require("../queries");
 
 const configureStore = require("../create-store");
 
-function createStore(threadClient) {
+function createStore(threadClient, initialState = {}) {
   return configureStore({
     log: false,
     makeThunkArgs: args => {
       return Object.assign({}, args, { threadClient: threadClient });
     }
-  })(combineReducers(reducers));
+  })(combineReducers(reducers), initialState);
 }
 
 function commonLog(msg, data = {}) {


### PR DESCRIPTION
Added two select source tests

Refactoring:
+ created a fixtures.json (cleaned up some fixture drift)
+ removed intermediate describe/beforeEach

I'd like to considering having a util file for actions so that the two mock clients could go there. One problem is that currently any non-hidden file in a test dir will be considered a test file. What do you think of having a suffix like spec (e.g. selectSource.spec.js)?