### PR TITLE
Add Eslint object-curly-spacing rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -297,7 +297,7 @@
     // Disallow unreachable statements after a return, throw, continue, or break
     // statement.
     "no-unreachable": 2,
-    // Disallow global and local variables that aren't used, but allow unused function arguments.
+    // Disallow global and local variables that arent used, but allow unused function arguments.
     "no-unused-vars": [2, {"vars": "all", "args": "none"}],
     // Allow using variables before they are defined.
     "no-use-before-define": 0,
@@ -308,7 +308,10 @@
     "no-warning-comments": 0,
     // Disallow use of the with statement.
     "no-with": 2,
-    // Don't require method and property shorthand syntax for object literals.
+    "object-curly-spacing": ["error", "always", {
+      "objectsInObjects": false,
+    }],
+    // Dont require method and property shorthand syntax for object literals.
     // We use this in the code a lot, but not consistently, and this seems more
     // like something to check at code review time.
     "object-shorthand": 0,
@@ -316,7 +319,7 @@
     "one-var": 0,
     // Disallow padding within blocks.
     "padded-blocks": [2, "never"],
-    // Don't require quotes around object literal property names.
+    // Dont require quotes around object literal property names.
     "quote-props": 0,
     // Double quotes should be used.
     "quotes": [2, "double", "avoid-escape"],
@@ -326,7 +329,7 @@
     "semi": [2, "always"],
     // Enforce spacing after semicolons.
     "semi-spacing": [2, {"before": false, "after": true}],
-    // Don't require to sort variables within the same declaration block.
+    // Dont require to sort variables within the same declaration block.
     // Anyway, one-var is disabled.
     "sort-vars": 0,
     // Deprecated, will be removed in 1.0.
@@ -340,7 +343,7 @@
     // Disallow space before function opening parenthesis.
     "space-before-function-paren": [2, "never"],
     // Disable the rule that checks if spaces inside {} and [] are there or not.
-    // Our code is split on conventions, and it'd be nice to have 2 rules
+    // Our code is split on conventions, and itd be nice to have 2 rules
     // instead, one for [] and one for {}. So, disabling until we write them.
     "space-in-brackets": 0,
     // Disallow spaces inside parentheses.
@@ -367,7 +370,7 @@
     "valid-typeof": 2,
     // Allow vars to be declared anywhere in the scope.
     "vars-on-top": 0,
-    // Don't require immediate function invocation to be wrapped in parentheses.
+    // Dont require immediate function invocation to be wrapped in parentheses.
     "wrap-iife": 0,
     // Don't require regex literals to be wrapped in parentheses (which
     // supposedly prevent them from being mistaken for division operators).

--- a/public/js/actions/pause.js
+++ b/public/js/actions/pause.js
@@ -29,7 +29,7 @@ function paused(pauseInfo) {
 /**
  * Debugger commands like stepOver, stepIn, stepUp
  */
-function command({type}) {
+function command({ type }) {
   return ({ dispatch, threadClient }) => {
     // execute debugger thread command e.g. stepIn, stepOver
     threadClient[type]();

--- a/public/js/actions/tabs.js
+++ b/public/js/actions/tabs.js
@@ -6,7 +6,7 @@
 const { Task } = require("ff-devtools-libs/sham/task");
 const { PROMISE } = require("ff-devtools-libs/client/shared/redux/middleware/promise");
 
-const { connectToTab} = require("../client");
+const { connectToTab } = require("../client");
 const constants = require("../constants");
 const { getTabs } = require("../selectors");
 

--- a/public/js/components/App.js
+++ b/public/js/components/App.js
@@ -29,7 +29,7 @@ const App = React.createClass({
       right: SplitBox({
         initialWidth: 300,
         rightFlex: true,
-        left: dom.div({className: "editor-container"},
+        left: dom.div({ className: "editor-container" },
           SourceTabs(),
           Editor()
         ),

--- a/public/js/components/Breakpoints.js
+++ b/public/js/components/Breakpoints.js
@@ -63,9 +63,9 @@ const Breakpoints = React.createClass({
       dom.input({ type: "checkbox",
                   checked: !breakpoint.get("disabled"),
                   onChange: () => this.handleCheckbox(breakpoint) }),
-      dom.div({className: "breakpoint-label"}, `${filename}, line ${line}`),
+      dom.div({ className: "breakpoint-label" }, `${filename}, line ${line}`),
       (isCurrentlyPaused && Isvg({ className: "pause-indicator",
-                                   src: "images/pause-circle.svg"}))
+                                   src: "images/pause-circle.svg" }))
     );
   },
 

--- a/public/js/components/RightSidebar.js
+++ b/public/js/components/RightSidebar.js
@@ -16,15 +16,15 @@ require("./RightSidebar.css");
 function debugBtn(onClick, type, className) {
   return dom.span(
     { onClick, className, key: type },
-    Isvg({ src: `images/${type}.svg`})
+    Isvg({ src: `images/${type}.svg` })
   );
 }
 
 function RightSidebar({ resume, command, breakOnNext,
                         pause, isWaitingOnBreak }) {
   return (
-    dom.div({className: "right-sidebar"},
-      dom.div({className: "command-bar"},
+    dom.div({ className: "right-sidebar" },
+      dom.div({ className: "command-bar" },
         (
           pause
             ? [
@@ -49,7 +49,7 @@ function RightSidebar({ resume, command, breakOnNext,
             component: Breakpoints,
             opened: true },
           { header: "Call Stack",
-            component: () => dom.div({className: "pane-info"}, "Not Paused")
+            component: () => dom.div({ className: "pane-info" }, "Not Paused")
           },
           { header: "Scopes",
             component: Scopes

--- a/public/js/components/SourceTabs.js
+++ b/public/js/components/SourceTabs.js
@@ -28,15 +28,15 @@ function sourceTab(selectedSource) {
   const url = selectedSource && selectedSource.get("url");
   const filename = getFilename(url);
 
-  return dom.div({className: "source-tab"},
-    dom.div({className: "filename"}, filename),
+  return dom.div({ className: "source-tab" },
+    dom.div({ className: "filename" }, filename),
     Isvg({ className: "close-btn", src: "images/close.svg" })
   );
 }
 
 function SourceTabs({ selectedSource }) {
   return (
-    dom.div({className: "source-tabs"},
+    dom.div({ className: "source-tabs" },
       selectedSource ? sourceTab(selectedSource) : ""
     )
   );

--- a/public/js/components/Sources.js
+++ b/public/js/components/Sources.js
@@ -13,7 +13,7 @@ function isSelected(selectedSource, source) {
   return selectedSource && selectedSource.get("actor") == source.get("actor");
 }
 
-function renderSource({source, selectSource, selectedSource}) {
+function renderSource({ source, selectSource, selectedSource }) {
   const pathname = source.get("pathname");
   const selectedClass = isSelected(selectedSource, source) ? "selected" : "";
 
@@ -21,7 +21,7 @@ function renderSource({source, selectSource, selectedSource}) {
     { onClick: () => selectSource(source.toJS()),
       className: `source-item ${selectedClass}`,
       style: { paddingLeft: "40px" },
-      key: source.get("url")},
+      key: source.get("url") },
     pathname
   );
 }
@@ -41,13 +41,13 @@ function groupSourcesByDomain(sources) {
 function Sources({ sources, selectSource, selectedSource }) {
   const sourcesByDomain = groupSourcesByDomain(sources);
 
-  return dom.div({className: "sources-panel"},
-    dom.div({className: "sources-header"}, ""),
+  return dom.div({ className: "sources-panel" },
+    dom.div({ className: "sources-header" }, ""),
     dom.ul(
-      {className: "sources-list"},
+      { className: "sources-list" },
       sourcesByDomain.keySeq().map((domain) => {
         return dom.li({ key: domain, className: "domain" },
-          dom.span({style: { paddingLeft: "20px" }}, domain),
+          dom.span({ style: { paddingLeft: "20px" }}, domain),
           dom.ul(null,
             sourcesByDomain.get(domain).map(source => renderSource({
               source, selectSource, selectedSource }))

--- a/public/js/components/stories/Breakpoints.js
+++ b/public/js/components/stories/Breakpoints.js
@@ -58,11 +58,11 @@ storiesOf("Breakpoints", module)
   });
 
 function renderBreakpoints(store) {
-  return dom.div({style: {
+  return dom.div({ style: {
     width: "300px",
     margin: "auto",
     paddingTop: "100px" }},
-    dom.div({style: {border: "1px solid #ccc", padding: "20px" }},
+    dom.div({ style: { border: "1px solid #ccc", padding: "20px" }},
       createElement(Provider, { store }, Breakpoints())
     )
   );

--- a/public/js/components/stories/accordion.js
+++ b/public/js/components/stories/accordion.js
@@ -7,13 +7,13 @@ const { storiesOf } = require("@kadira/storybook");
 
 let items = [
   { header: "Breakpoints",
-    component: () => dom.div({className: "pane-info"}, "No Breakpoints")
+    component: () => dom.div({ className: "pane-info" }, "No Breakpoints")
   },
   { header: "Call Stack",
-    component: () => dom.div({className: "pane-info"}, "Not Paused")
+    component: () => dom.div({ className: "pane-info" }, "Not Paused")
   },
   { header: "Scopes",
-    component: () => dom.div({className: "pane-info"}, "Not Paused")
+    component: () => dom.div({ className: "pane-info" }, "Not Paused")
   }
 ];
 

--- a/public/js/util/editor.js
+++ b/public/js/util/editor.js
@@ -40,7 +40,7 @@ function alignLine(cm, line, align = "top") {
  * Scrolls the view such that the given line number is the first visible line.
  */
 function setFirstVisibleLine(cm, line) {
-  let { top } = cm.charCoords({line: line, ch: 0}, "local");
+  let { top } = cm.charCoords({ line: line, ch: 0 }, "local");
   cm.scrollTo(0, top);
 }
 


### PR DESCRIPTION
This will enforce a whitespace character between objects and their
properties. It does not force nested object curlies to have whitespace
e.g. { x: { a: 2 }} is okay.

I think it is okay to change eslint if we're becoming stricter, of course going the other way is different.