### PR TITLE
Update npm test scripts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,12 @@
 test:
+  override:
+    - mkdir -p $CIRCLE_TEST_REPORTS/mocha
+    - node_modules/.bin/mocha --compilers js:babel-register --reporter mocha-circleci-reporter --reporter-options mochaFile=$CIRCLE_TEST_REPORTS/mocha/junit.xml public/js/**/tests/*
   pre:
     - npm install
   post:
     - npm run lint-css
     - npm run lint-js
-    - npm run test
     - npm run test-karma
 dependencies:
   override:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "debugger.html",
   "scripts": {
     "start": "firefox-proxy & node bin/server",
+    "lint": "npm run lint-css; npm run lint-js",
     "lint-css": "stylelint public/js/components/*.css",
     "lint-js": "eslint public/js",
     "test": "mocha --compilers js:babel-register public/js/**/tests/*",
@@ -56,6 +57,7 @@
     "karma-firefox-launcher": "^0.1.7",
     "karma-mocha": "^0.2.2",
     "karma-webpack": "^1.7.0",
+    "mocha-circleci-reporter": "0.0.1",
     "rimraf": "^2.5.2",
     "style-loader": "^0.13.1"
   }


### PR DESCRIPTION
I've noticed that it's common for me to create a PR without first
linting. This change updates `npm test` so that it runs node mocha as
well as the linters.

When that happens, circle ci also becomes a bit simpler.