### PR TITLE
Scopes (Part 2)

### DIFF
--- a/public/js/components/Scopes.css
+++ b/public/js/components/Scopes.css
@@ -1,22 +1,16 @@
-.scopes-pane ul.scopes-list {
-  list-style: none;
-  padding: 0;
-}
-
-.scopes-pane li.scope-item {
-  color: var(--theme-content-color1);
-  font-weight: bold;
-  padding-left: 10px;
-  margin-bottom: 20px;
-}
-
 .scopes-pane ul.scope-property-list {
   list-style: none;
   padding: 0;
 }
 
+.scopes-pane li.scope-property-list-item:first-child {
+  border-top: 1px solid #eeeeee;
+}
+
 .scopes-pane li.scope-property-list-item {
-  color: var(--theme-content-color1);
+  color: var(--theme-content-color2);
   padding-left: 10px;
   font-weight: normal;
+  border-bottom: 1px solid #eeeeee;
+  line-height: 2em;
 }

--- a/public/js/components/Scopes.js
+++ b/public/js/components/Scopes.js
@@ -25,10 +25,6 @@ function getScopes(pauseInfo) {
   return scopes;
 }
 
-function getScopeVariables(scope) {
-  return scope.getIn(["bindings", "variables"]);
-}
-
 function renderArgumentProperty(argumentBinding) {
   const argumentName = argumentBinding.keySeq().first();
   const actor = argumentBinding.first().getIn(["value", "actor"]);
@@ -70,11 +66,13 @@ function renderFunctionScope(scope, isFirst) {
 }
 
 /* TODO: render block with variables */
-function renderBlockScope(scope) {
-  const variables = getScopeVariables(scope);
-  if (variables.isEmpty()) {
-    return;
-  }
+function renderBlockScope(scope, isFirst) {
+  const label = "Block Scope";
+  return dom.li(
+    { className: "scope-item", key: scope.get("actor") },
+    dom.div({ className: "scope-label" }, (isFirst ? "Local " : "") + label),
+    renderScopeBindings(scope.get("bindings"))
+  );
 }
 
 function renderObjectScope(scope) {

--- a/public/js/components/Scopes.js
+++ b/public/js/components/Scopes.js
@@ -6,6 +6,7 @@ const { connect } = require("react-redux");
 const actions = require("../actions");
 const { getPause } = require("../selectors");
 const { DOM: dom } = React;
+const Accordion = React.createFactory(require("./Accordion"));
 
 require("./Scopes.css");
 
@@ -55,34 +56,34 @@ function renderScopeBindings(bindings) {
 
 function renderFunctionScope(scope, isFirst) {
   const displayName = scope.getIn(["function", "displayName"]);
-  const functionClass = scope.getIn(["function", "class"]);
+  const functionName = displayName || "(anonymous)";
 
-  const label = displayName || functionClass;
-  return dom.li(
-    { className: "scope-item", key: scope.get("actor") },
-    dom.div({ className: "scope-label" }, (isFirst ? "Local " : "") + label),
-    renderScopeBindings(scope.get("bindings"))
-  );
+  return {
+    header: `Function [${functionName}]`,
+    component: () => renderScopeBindings(scope.get("bindings")),
+    opened: isFirst
+  };
 }
 
 /* TODO: render block with variables */
 function renderBlockScope(scope, isFirst) {
   const label = "Block Scope";
-  return dom.li(
-    { className: "scope-item", key: scope.get("actor") },
-    dom.div({ className: "scope-label" }, (isFirst ? "Local " : "") + label),
-    renderScopeBindings(scope.get("bindings"))
-  );
+  return {
+    header: label,
+    component: () => renderScopeBindings(scope.get("bindings")),
+    opened: isFirst
+  };
 }
 
-function renderObjectScope(scope) {
+function renderObjectScope(scope, isFirst) {
   const objectClass = scope.getIn(["object", "class"]);
   const label = objectClass;
 
-  return dom.li(
-    { className: "scope-item", key: scope.get("actor") },
-    dom.div({ className: "scope-label" }, label)
-  );
+  return {
+    header: label,
+    component: () => dom.div(),
+    opened: isFirst
+  };
 }
 
 function renderScope(scope, index) {
@@ -100,7 +101,7 @@ function Scopes({ pauseInfo }) {
   return dom.div({ className: "scopes-pane" },
     !pauseInfo ?
     dom.div({ className: "pane-info" }, "Not Paused")
-    : dom.ul({ className: "scopes-list" }, scopes.map(renderScope))
+    : Accordion({ items: scopes.map(renderScope) })
   );
 }
 

--- a/public/js/components/stories/Breakpoints.js
+++ b/public/js/components/stories/Breakpoints.js
@@ -3,56 +3,33 @@
 const React = require("react");
 const { DOM: dom, createElement } = React;
 const { storiesOf } = require("@kadira/storybook");
-const configureStore = require("../../create-store");
-const { combineReducers } = require("redux");
-const reducers = require("../../reducers");
 const { Provider } = require("react-redux");
-const { fromJS } = require("immutable");
+const { createStore } = require("./utils");
 
 const Breakpoints = React.createFactory(require("../Breakpoints"));
 const fixtures = require("../../test/fixtures.json");
 
+const fooSourceActor = fixtures.sources.sources.fooSourceActor;
+const barSourceActor = fixtures.sources.sources.barSourceActor;
+const fooBreakpointActor = fixtures.breakpoints.fooBreakpointActor;
+const barBreakpointActor = fixtures.breakpoints.barBreakpointActor;
+
 storiesOf("Breakpoints", module)
   .add("No Breakpoints", () => {
-    const store = configureStore({})(combineReducers(reducers), {
-      sources: fromJS({
-        sources: {}
-      }),
-      breakpoints: fromJS({
-        breakpoints: {}
-      })
-    });
+    const store = createStore();
     return renderBreakpoints(store);
   })
   .add("1 Domain", () => {
-    const store = configureStore({})(combineReducers(reducers), {
-      sources: fromJS({
-        sources: {
-          "fooSourceActor": fixtures.sources.sources.fooSourceActor,
-        }
-      }),
-      breakpoints: fromJS({
-        breakpoints: {
-          "fooBreakpointActor": fixtures.breakpoints.fooBreakpointActor,
-        }
-      })
+    const store = createStore({
+      sources: { fooSourceActor },
+      breakpoints: { fooBreakpointActor }
     });
     return renderBreakpoints(store);
   })
   .add("2 Domains", () => {
-    const store = configureStore({})(combineReducers(reducers), {
-      sources: fromJS({
-        sources: {
-          "fooSourceActor": fixtures.sources.sources.fooSourceActor,
-          "barSourceActor": fixtures.sources.sources.barSourceActor,
-        }
-      }),
-      breakpoints: fromJS({
-        breakpoints: {
-          "fooBreakpointActor": fixtures.breakpoints.fooBreakpointActor,
-          "barBreakpointActor": fixtures.breakpoints.barBreakpointActor,
-        }
-      })
+    const store = createStore({
+      sources: { fooSourceActor, barSourceActor },
+      breakpoints: { fooBreakpointActor, barBreakpointActor }
     });
     return renderBreakpoints(store);
   });

--- a/public/js/components/stories/Scopes.js
+++ b/public/js/components/stories/Scopes.js
@@ -1,0 +1,33 @@
+"use strict";
+const React = require("react");
+const { DOM: dom, createElement } = React;
+const { Provider } = require("react-redux");
+
+const { createStore } = require("./utils");
+
+const { storiesOf } = require("@kadira/storybook");
+const Scopes = React.createFactory(require("../Scopes"));
+
+const backbonePauseOnEnter =
+  require("../../test/fixtures/backbone.pause.onEnter.json");
+
+storiesOf("Scopes", module)
+  .add("Not Paused", () => {
+    const store = createStore();
+    return renderContainer(store, Scopes);
+  })
+  .add("Event Handler", () => {
+    const store = createStore({ pause: backbonePauseOnEnter });
+    return renderContainer(store, Scopes);
+  });
+
+function renderContainer(store, Component) {
+  return dom.div({style: {
+    width: "300px",
+    margin: "auto",
+    paddingTop: "100px" }},
+    dom.div({style: {border: "1px solid #ccc", padding: "20px" }},
+      createElement(Provider, { store }, Component())
+    )
+  );
+}

--- a/public/js/components/stories/index.js
+++ b/public/js/components/stories/index.js
@@ -3,4 +3,5 @@
 require("./accordion");
 require("./Breakpoints");
 require("./editor");
+require("./Scopes");
 require("./SplitBox");

--- a/public/js/components/stories/utils.js
+++ b/public/js/components/stories/utils.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const configureStore = require("../../create-store");
+const { combineReducers } = require("redux");
+const reducers = require("../../reducers");
+const { fromJS } = require("immutable");
+
+function createStore({ sources = {}, breakpoints = {} } = {}) {
+  return configureStore({})(combineReducers(reducers), {
+    sources: fromJS({ sources }),
+    breakpoints: fromJS({ breakpoints })
+  });
+}
+
+module.exports = {
+  createStore
+};

--- a/public/js/components/stories/utils.js
+++ b/public/js/components/stories/utils.js
@@ -5,10 +5,11 @@ const { combineReducers } = require("redux");
 const reducers = require("../../reducers");
 const { fromJS } = require("immutable");
 
-function createStore({ sources = {}, breakpoints = {} } = {}) {
+function createStore({ sources = {}, breakpoints = {}, pause = {} } = {}) {
   return configureStore({})(combineReducers(reducers), {
     sources: fromJS({ sources }),
-    breakpoints: fromJS({ breakpoints })
+    breakpoints: fromJS({ breakpoints }),
+    pause: fromJS({ pause })
   });
 }
 

--- a/public/js/components/stories/utils.js
+++ b/public/js/components/stories/utils.js
@@ -5,7 +5,7 @@ const { combineReducers } = require("redux");
 const reducers = require("../../reducers");
 const { fromJS } = require("immutable");
 
-function createStore({ sources = {}, breakpoints = {}, pause = {} } = {}) {
+function createStore({ sources = {}, breakpoints = {}, pause = null } = {}) {
   return configureStore({})(combineReducers(reducers), {
     sources: fromJS({ sources }),
     breakpoints: fromJS({ breakpoints }),

--- a/public/js/test/fixtures/backbone.pause.onEnter.json
+++ b/public/js/test/fixtures/backbone.pause.onEnter.json
@@ -1,0 +1,502 @@
+{
+  "from": "server2.conn42.child1/context26",
+  "type": "paused",
+  "actor": "server2.conn42.child1/pause199",
+  "frame": {
+    "actor": "server2.conn42.child1/200",
+    "type": "call",
+    "callee": {
+      "frozen": false,
+      "displayName": "app.TodoView<.updateOnEnter",
+      "actor": "server2.conn42.child1/pausedobj201",
+      "location": {
+        "url": "http://todomvc.com/examples/backbone/js/views/todo-view.js",
+        "line": 102
+      },
+      "class": "Function",
+      "type": "object",
+      "extensible": true,
+      "sealed": false,
+      "parameterNames": [
+        "e"
+      ]
+    },
+    "environment": {
+      "actor": "server2.conn42.child1/202",
+      "type": "function",
+      "parent": {
+        "actor": "server2.conn42.child1/72",
+        "type": "function",
+        "parent": {
+          "actor": "server2.conn42.child1/73",
+          "type": "block",
+          "parent": {
+            "actor": "server2.conn42.child1/74",
+            "type": "object",
+            "object": {
+              "type": "object",
+              "class": "Window",
+              "actor": "server2.conn42.child1/pausedobj75",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "ownPropertyLength": 770,
+              "preview": {
+                "kind": "ObjectWithURL",
+                "url": "http://todomvc.com/examples/backbone/"
+              }
+            }
+          },
+          "bindings": {
+            "arguments": [],
+            "variables": {}
+          }
+        },
+        "function": {
+          "type": "object",
+          "class": "Function",
+          "actor": "server2.conn42.child1/pausedobj76",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "parameterNames": [
+            "$"
+          ],
+          "location": {
+            "url": "http://todomvc.com/examples/backbone/js/views/todo-view.js",
+            "line": 4
+          }
+        },
+        "bindings": {
+          "arguments": [
+            {
+              "$": {
+                "enumerable": true,
+                "configurable": false,
+                "value": {
+                  "type": "null",
+                  "optimizedOut": true
+                },
+                "writable": false
+              }
+            }
+          ],
+          "variables": {
+            "arguments": {
+              "enumerable": true,
+              "configurable": false,
+              "value": {
+                "type": "null",
+                "missingArguments": true
+              },
+              "writable": false
+            }
+          }
+        }
+      },
+      "function": {
+        "frozen": false,
+        "displayName": "app.TodoView<.updateOnEnter",
+        "actor": "server2.conn42.child1/pausedobj203",
+        "location": {
+          "url": "http://todomvc.com/examples/backbone/js/views/todo-view.js",
+          "line": 102
+        },
+        "class": "Function",
+        "type": "object",
+        "extensible": true,
+        "sealed": false,
+        "parameterNames": [
+          "e"
+        ]
+      },
+      "bindings": {
+        "arguments": [
+          {
+            "e": {
+              "enumerable": true,
+              "configurable": false,
+              "value": {
+                "type": "object",
+                "class": "Object",
+                "actor": "server2.conn42.child1/pausedobj204",
+                "extensible": true,
+                "frozen": false,
+                "sealed": false,
+                "ownPropertyLength": 24,
+                "preview": {
+                  "kind": "Object",
+                  "ownProperties": {
+                    "isDefaultPrevented": {
+                      "configurable": true,
+                      "enumerable": true,
+                      "writable": true,
+                      "value": {
+                        "frozen": false,
+                        "name": "returnFalse",
+                        "displayName": "returnFalse",
+                        "actor": "server2.conn42.child1/pausedobj206",
+                        "location": {
+                          "url": "http://todomvc.com/examples/backbone/node_modules/jquery/dist/jquery.js",
+                          "line": 4070
+                        },
+                        "class": "Function",
+                        "type": "object",
+                        "extensible": true,
+                        "sealed": false,
+                        "parameterNames": []
+                      }
+                    },
+                    "charCode": {
+                      "configurable": true,
+                      "enumerable": true,
+                      "writable": true,
+                      "value": 0
+                    },
+                    "originalEvent": {
+                      "configurable": true,
+                      "enumerable": true,
+                      "writable": true,
+                      "value": {
+                        "type": "object",
+                        "class": "KeyboardEvent",
+                        "actor": "server2.conn42.child1/pausedobj205",
+                        "extensible": true,
+                        "frozen": false,
+                        "sealed": false,
+                        "ownPropertyLength": 1,
+                        "preview": {
+                          "kind": "DOMEvent",
+                          "type": "keypress",
+                          "properties": {
+                            "key": "Enter",
+                            "charCode": 0,
+                            "keyCode": 13
+                          },
+                          "eventKind": "key",
+                          "modifiers": []
+                        }
+                      }
+                    },
+                    "keyCode": {
+                      "configurable": true,
+                      "enumerable": true,
+                      "writable": true,
+                      "value": 13
+                    },
+                    "timeStamp": {
+                      "configurable": true,
+                      "enumerable": true,
+                      "writable": true,
+                      "value": 89424511
+                    },
+                    "char": {
+                      "configurable": true,
+                      "enumerable": true,
+                      "writable": true,
+                      "value": {
+                        "type": "undefined"
+                      }
+                    },
+                    "type": {
+                      "configurable": true,
+                      "enumerable": true,
+                      "writable": true,
+                      "value": "keypress"
+                    },
+                    "jQuery21409680306905055901": {
+                      "configurable": true,
+                      "enumerable": true,
+                      "writable": true,
+                      "value": true
+                    },
+                    "which": {
+                      "configurable": true,
+                      "enumerable": true,
+                      "writable": true,
+                      "value": 13
+                    },
+                    "key": {
+                      "configurable": true,
+                      "enumerable": true,
+                      "writable": true,
+                      "value": "Enter"
+                    }
+                  },
+                  "ownPropertiesLength": 24
+                }
+              },
+              "writable": true
+            }
+          }
+        ],
+        "variables": {
+          "arguments": {
+            "enumerable": true,
+            "configurable": false,
+            "value": {
+              "type": "object",
+              "class": "Arguments",
+              "actor": "server2.conn42.child1/pausedobj207",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "ownPropertyLength": 4,
+              "preview": {
+                "kind": "Object",
+                "ownProperties": {},
+                "ownPropertiesLength": 4,
+                "safeGetterValues": {}
+              }
+            },
+            "writable": true
+          }
+        }
+      }
+    },
+    "this": {
+      "type": "object",
+      "class": "Object",
+      "actor": "server2.conn42.child1/pausedobj208",
+      "extensible": true,
+      "frozen": false,
+      "sealed": false,
+      "ownPropertyLength": 7,
+      "preview": {
+        "kind": "Object",
+        "ownProperties": {
+          "cid": {
+            "configurable": true,
+            "enumerable": true,
+            "writable": true,
+            "value": "view23"
+          },
+          "model": {
+            "configurable": true,
+            "enumerable": true,
+            "writable": true,
+            "value": {
+              "type": "object",
+              "class": "Object",
+              "actor": "server2.conn42.child1/pausedobj209",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "ownPropertyLength": 11
+            }
+          },
+          "$el": {
+            "configurable": true,
+            "enumerable": true,
+            "writable": true,
+            "value": {
+              "type": "object",
+              "class": "Object",
+              "actor": "server2.conn42.child1/pausedobj210",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "ownPropertyLength": 3
+            }
+          },
+          "el": {
+            "configurable": true,
+            "enumerable": true,
+            "writable": true,
+            "value": {
+              "type": "object",
+              "class": "HTMLLIElement",
+              "actor": "server2.conn42.child1/pausedobj211",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "ownPropertyLength": 2,
+              "preview": {
+                "kind": "DOMNode",
+                "nodeType": 1,
+                "nodeName": "li",
+                "attributes": {
+                  "class": "editing"
+                },
+                "attributesLength": 1
+              }
+            }
+          },
+          "_listeningTo": {
+            "configurable": true,
+            "enumerable": true,
+            "writable": true,
+            "value": {
+              "type": "object",
+              "class": "Object",
+              "actor": "server2.conn42.child1/pausedobj212",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "ownPropertyLength": 1
+            }
+          },
+          "_listenId": {
+            "configurable": true,
+            "enumerable": true,
+            "writable": true,
+            "value": "l25"
+          },
+          "$input": {
+            "configurable": true,
+            "enumerable": true,
+            "writable": true,
+            "value": {
+              "type": "object",
+              "class": "Object",
+              "actor": "server2.conn42.child1/pausedobj213",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "ownPropertyLength": 5
+            }
+          }
+        },
+        "ownPropertiesLength": 7,
+        "safeGetterValues": {}
+      }
+    },
+    "arguments": [
+      {
+        "type": "object",
+        "class": "Object",
+        "actor": "server2.conn42.child1/pausedobj214",
+        "extensible": true,
+        "frozen": false,
+        "sealed": false,
+        "ownPropertyLength": 24,
+        "preview": {
+          "kind": "Object",
+          "ownProperties": {
+            "isDefaultPrevented": {
+              "configurable": true,
+              "enumerable": true,
+              "writable": true,
+              "value": {
+                "frozen": false,
+                "name": "returnFalse",
+                "displayName": "returnFalse",
+                "actor": "server2.conn42.child1/pausedobj206",
+                "location": {
+                  "url": "http://todomvc.com/examples/backbone/node_modules/jquery/dist/jquery.js",
+                  "line": 4070
+                },
+                "class": "Function",
+                "type": "object",
+                "extensible": true,
+                "sealed": false,
+                "parameterNames": []
+              }
+            },
+            "charCode": {
+              "configurable": true,
+              "enumerable": true,
+              "writable": true,
+              "value": 0
+            },
+            "originalEvent": {
+              "configurable": true,
+              "enumerable": true,
+              "writable": true,
+              "value": {
+                "type": "object",
+                "class": "KeyboardEvent",
+                "actor": "server2.conn42.child1/pausedobj205",
+                "extensible": true,
+                "frozen": false,
+                "sealed": false,
+                "ownPropertyLength": 1,
+                "preview": {
+                  "kind": "DOMEvent",
+                  "type": "keypress",
+                  "properties": {
+                    "key": "Enter",
+                    "charCode": 0,
+                    "keyCode": 13
+                  },
+                  "eventKind": "key",
+                  "modifiers": []
+                }
+              }
+            },
+            "keyCode": {
+              "configurable": true,
+              "enumerable": true,
+              "writable": true,
+              "value": 13
+            },
+            "timeStamp": {
+              "configurable": true,
+              "enumerable": true,
+              "writable": true,
+              "value": 89424511
+            },
+            "char": {
+              "configurable": true,
+              "enumerable": true,
+              "writable": true,
+              "value": {
+                "type": "undefined"
+              }
+            },
+            "type": {
+              "configurable": true,
+              "enumerable": true,
+              "writable": true,
+              "value": "keypress"
+            },
+            "jQuery21409680306905055901": {
+              "configurable": true,
+              "enumerable": true,
+              "writable": true,
+              "value": true
+            },
+            "which": {
+              "configurable": true,
+              "enumerable": true,
+              "writable": true,
+              "value": 13
+            },
+            "key": {
+              "configurable": true,
+              "enumerable": true,
+              "writable": true,
+              "value": "Enter"
+            }
+          },
+          "ownPropertiesLength": 24
+        }
+      }
+    ],
+    "where": {
+      "source": {
+        "actor": "server2.conn42.child1/source34",
+        "url": "http://todomvc.com/examples/backbone/js/views/todo-view.js",
+        "addonID": null,
+        "addonPath": null,
+        "isBlackBoxed": false,
+        "isPrettyPrinted": false,
+        "introductionUrl": null,
+        "introductionType": "scriptElement"
+      },
+      "line": 103,
+      "column": 0,
+      "actor": "server2.conn42.child1/source34"
+    }
+  },
+  "poppedFrames": [
+    "server2.conn42.child1/189"
+  ],
+  "why": {
+    "type": "breakpoint",
+    "actors": [
+      "server2.conn42.child1/176"
+    ]
+  },
+  "isInterrupted": false
+}


### PR DESCRIPTION
Updates:
+ Refactored Storybook's `createStore` to support fixtures
+ Change block scope behavior to always show (consistent w/ firefox)
+ Change function scope labels to support anonymous and always have the word function.
+ Add scope accordions for styling and collapsing large scopes