### PR TITLE
reduce the repetition of frame location

### DIFF
--- a/public/js/components/Frames.js
+++ b/public/js/components/Frames.js
@@ -23,20 +23,27 @@ function renderFrameTitle(frame) {
   return div({ className: "title" }, title);
 }
 
-function renderFrameLocation(frame) {
-  return div({ className: "location" }, basename(frame.where.source.url));
+function renderFrameLocation(frame, lastFrame) {
+  if (!lastFrame || lastFrame.where.source.url !== frame.where.source.url) {
+    return div({ className: "location" }, basename(frame.where.source.url));
+  }
+  return div({ className: "location" }, "");
 }
 
 function Frames({ frames, selectedFrame, selectFrame }) {
+  let lastFrame = null;
   return div(
     { className: "pane-info frames" },
     !frames ?
       div({ className: "empty" }, "Not Paused") :
-      dom.ul(null, frames.map(frame => {
+      dom.ul(null, frames.map((frame, i, a) => {
+        if (i > 0 && a[i - 1]) {
+          lastFrame = a[i - 1];
+        }
         return dom.li({ className: selectedFrame === frame ? "selected" : "",
                         onClick: () => selectFrame(frame)
                       },
-                      renderFrameLocation(frame),
+                      renderFrameLocation(frame, lastFrame),
                       renderFrameTitle(frame));
       }))
   );


### PR DESCRIPTION
**Don't Merge This**
![screen shot 2016-05-03 at 12 33 49 pm](https://cloud.githubusercontent.com/assets/2134/14996073/f435ed4a-112c-11e6-84e6-07947e7280a9.png)


This is just a hack attempt at only listing the frame location when its unique to the frame before it.

Currently you can the same frame source location repeated over and over.  While the line number may be unique and should be displayed we should avoid repeating ourselves like this.