### PR TITLE
add proxy to dev-server

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -7,6 +7,8 @@ const express = require("express");
 const projectConfig = require("../webpack.config");
 const webpackDevMiddleware = require("webpack-dev-middleware");
 
+require("ff-devtools-libs/bin/firefox-proxy");
+
 const config = Object.assign({}, projectConfig, {
   entry: path.join(__dirname, "../public/js/main.js"),
 });
@@ -33,5 +35,5 @@ app.listen(8000, "localhost", function(err, result) {
     console.log(err);
   }
 
-  console.log("Listening at http://localhost:8000");
+  console.log("Development Server Listening at http://localhost:8000");
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "debugger.html",
   "scripts": {
-    "start": "firefox-proxy & node bin/server",
+    "start": "node bin/server",
     "lint": "npm run lint-css; npm run lint-js",
     "lint-css": "stylelint public/js/components/*.css",
     "lint-js": "eslint public/js",


### PR DESCRIPTION
This PR makes the proxy a dependency of the server. The rationale is that both the  firefox-proxy and server are useful for the local development environment, but not necessarily useful when the debugger is in the FF toolbox. 

Going forward, I'd like to refactor the proxy so that it has a better api `proxy.start({ clientPort: 9000, browserPort: 6080 })`.

Also, I've noticed that if integration tests are running in the background and you happen to be testing manually as well, there can be miscommunications between the two debuggers and two debuggees. The solution, would be to have the testing environment communicate over different ports 9001, 6081. We could do that by adding the clienPort to the config.js and maybe having a testing config as well, although from experience, the testing config should default to production.