### PR TITLE
Add displayName to all components.

### DIFF
--- a/public/js/components/Accordion.js
+++ b/public/js/components/Accordion.js
@@ -13,6 +13,8 @@ const Accordion = React.createClass({
     items: PropTypes.array
   },
 
+  displayName: "Accordion",
+
   getInitialState: function() {
     return { opened: this.props.items.map(item => item.opened),
              created: [] };

--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -40,6 +40,8 @@ const _Breakpoint = React.createClass({
     editor: PropTypes.object
   },
 
+  displayName: "Breakpoint",
+
   componentWillMount: function() {
     const bp = this.props.breakpoint;
     const line = bp.getIn(["location", "line"]) - 1;

--- a/public/js/components/Sources.js
+++ b/public/js/components/Sources.js
@@ -35,6 +35,8 @@ let SourcesTree = React.createClass({
     selectSource: PropTypes.func.isRequired
   },
 
+  displayName: "SourcesTree",
+
   makeInitialState(props) {
     const tree = createNode("root", "", []);
     for (let source of props.sources.valueSeq()) {

--- a/public/js/components/util/ManagedTree.js
+++ b/public/js/components/util/ManagedTree.js
@@ -6,6 +6,8 @@ const Tree = React.createFactory(require("../../lib/tree"));
 let ManagedTree = React.createClass({
   propTypes: Tree.propTypes,
 
+  displayName: "ManagedTree",
+
   getInitialState() {
     return { expanded: new WeakMap(),
              focusedItem: null };

--- a/public/js/lib/tree.js
+++ b/public/js/lib/tree.js
@@ -46,6 +46,8 @@ const ArrowExpander = createFactory(createClass({
 }));
 
 const TreeNode = createFactory(createClass({
+  displayName: "TreeNode",
+
   componentDidMount() {
     if (this.props.focused) {
       this.refs.button.focus();


### PR DESCRIPTION
I'm reviewing the new tree sources, and the display names were missing on several components. I added them here so that the React add-on displays better information.

![screen shot 2016-05-16 at 1 43 32 pm](https://cloud.githubusercontent.com/assets/1588648/15300091/991ef948-1b6c-11e6-8917-822d8fe12735.png)
