### PR TITLE
small tweaks to make first run experience better

### DIFF
--- a/bin/development-server.js
+++ b/bin/development-server.js
@@ -5,7 +5,6 @@ const path = require("path");
 const webpack = require("webpack");
 const express = require("express");
 const webpackDevMiddleware = require("webpack-dev-middleware");
-const open = require("openurl").open;
 const http = require("http");
 
 const projectConfig = require("../webpack.config");
@@ -91,5 +90,3 @@ app.listen(8000, "localhost", function(err, result) {
 
   console.log("Development Server Listening at http://localhost:8000");
 });
-
-open("http://localhost:8000")

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "karma": "^0.13.22",
     "mocha": "^2.4.5",
     "net": "^1.0.2",
-    "openurl": "^1.1.1",
     "react": "=0.14.7",
     "react-dom": "=0.14.7",
     "react-immutable-proptypes": "^1.7.1",

--- a/public/js/configs/development.json
+++ b/public/js/configs/development.json
@@ -3,7 +3,7 @@
   "logging": true,
   "clientLogging": false,
   "chrome": {
-    "debug": true,
+    "debug": false,
     "webSocketPort": 9222
   }
 }


### PR DESCRIPTION
Before I open my devtools PR, I wanted to merge in these changes.

I rebased on master and found a few surprising things: `npm start` actually opens a new tab in my browser, which is very surprising. I'd like to remove this behavior, it's more annoying than helpful. If I'm debugging something that's requiring me to restart the server, a new tab is opened every single time even though I already have it open. I personally prefer to make tools more focused and not surprising. Developers can copy (or in iTerm, cmd+click) the URL in the terminal.

Additionally, chrome debugging is turned on by default, which makes Firefox continually spin because the request for chrome tabs never completes (I don't have it on). I definitely think it should be turned off by default. This makes the first run experience a lot better in my opinion.