### PR TITLE
support library compilation mode for usage inside devtools

### DIFF
--- a/public/js/components/Tabs.js
+++ b/public/js/components/Tabs.js
@@ -5,21 +5,25 @@ const { connect } = require("react-redux");
 const actions = require("../actions");
 const { bindActionCreators } = require("redux");
 const { getTabs } = require("../selectors");
-const { debugTab } = require("../clients/firefox");
+const { connectThread, initPage } = require("../clients/firefox");
 
 require("./Tabs.css");
 const dom = React.DOM;
 
-function renderTab(tab, boundActions) {
-  function onSelect(selectedTab) {
-    selectedTab = selectedTab.get("firefox") || selectedTab.get("chrome");
-    debugTab(selectedTab, boundActions);
-  }
+function onTabSelect(selectedTab, boundActions) {
+  const tab = selectedTab.get("firefox") || selectedTab.get("chrome");
 
+  boundActions.selectTab({ tabActor: tab.actor });
+  connectThread(tab).then(() => {
+    initPage(boundActions);
+  });
+}
+
+function renderTab(tab, boundActions) {
   return dom.li(
     { "className": "tab",
       "key": tab.get("id"),
-      "onClick": () => onSelect(tab) },
+      "onClick": () => onTabSelect(tab, boundActions) },
     dom.div({ className: "tab-title" }, tab.get("title")),
     dom.div({ className: "tab-url" }, tab.get("url"))
   );

--- a/webpack.config.devtools.js
+++ b/webpack.config.devtools.js
@@ -1,0 +1,15 @@
+"use strict";
+
+const config = require("./webpack.config");
+const webpack = require('webpack');
+
+config.output.library = "Debugger";
+config.plugins.push(
+  new webpack.DefinePlugin({
+    "process.env": {
+      NODE_ENV: JSON.stringify("DEVTOOLS_PANEL")
+    }
+  })
+);
+
+module.exports = config;


### PR DESCRIPTION
This will quickly conflict with your work on Chrome, but here is what I did to get it working as an external bundle. I think the key thing is that the bootstrapping process lives outside of the core system. So `debugTab` does not exist anymore, it's more broken down into smaller pieces that whatever is driving the system can choose what to run.

Saw your other PR and will comment in there as well.