### PR TITLE
Start Conditional Breakpoints

### DIFF
--- a/public/js/actions/breakpoints.js
+++ b/public/js/actions/breakpoints.js
@@ -150,11 +150,11 @@ function setBreakpointCondition(location, condition) {
       throw new Error("breakpoint must be saved");
     }
 
-    const bpClient = getBreakpointClient(bp.actor);
+    const bpClient = getBreakpointClient(bp.get("actor"));
 
     return dispatch({
       type: constants.SET_BREAKPOINT_CONDITION,
-      breakpoint: bp,
+      breakpoint: bp.toJS(),
       condition: condition,
       [PROMISE]: Task.spawn(function* () {
         const newClient = yield bpClient.setCondition(threadClient, condition);

--- a/public/js/components/Editor.css
+++ b/public/js/components/Editor.css
@@ -48,3 +48,24 @@
 .debug-line .CodeMirror-activeline-background {
   display: none;
 }
+
+.conditional-breakpoint-panel {
+  border-top: 1px solid var(--theme-gray);
+  border-bottom: 1px solid var(--theme-gray);
+  cursor: initial;
+  margin: 1em 0;
+  position: relative;;
+}
+
+.conditional-breakpoint-panel .header {
+  background: var(--theme-toolbar-background);
+  color: var(--theme-body-color);
+  height: 2em;
+  padding: 0 0.5em;
+  line-height: 2em;
+}
+
+.conditional-breakpoint-panel input {
+  margin: 1em;
+  width: calc(100% - 2em);
+}


### PR DESCRIPTION
Turns out that adding conditional breakpoint involves a lot of wiring up :) who would have thought


![screen shot 2016-05-20 at 4 01 24 pm](https://cloud.githubusercontent.com/assets/254562/15440522/da9344d0-1ea3-11e6-9dd3-a43e43725a10.png)


This PR, can be added as is, but it is not feature complete. It adds:

1. a conditional bp panel that is shown when your command click on a bp
2. conditions are added to the bp on enter...

What is not added:
+ there is no panel close button
+ the badge is not changed to orange when it's a conditional bp
+ the condition is not shown in the breakpoint list