### PR TITLE
consolidate client APIs into a generic API interface

### DIFF
--- a/public/js/actions/breakpoints.js
+++ b/public/js/actions/breakpoints.js
@@ -7,7 +7,7 @@ const promise = require("ff-devtools-libs/sham/promise");
 const constants = require("../constants");
 const { PROMISE } = require("ff-devtools-libs/client/shared/redux/middleware/promise");
 const {
-  getSource, getBreakpoint, getBreakpoints
+  getBreakpoint, getBreakpoints
 } = require("../selectors");
 const { Task } = require("ff-devtools-libs/sham/task");
 const fromJS = require("../util/fromJS");
@@ -53,14 +53,10 @@ function addBreakpoint(location, condition, snippet) {
       breakpoint: bp.toJS(),
       condition: condition,
       [PROMISE]: Task.spawn(function* () {
-        const sourceClient = threadClient.source(
-          getSource(getState(), bp.getIn(["location", "sourceId"])).toJS()
+        const [response, bpClient] = yield threadClient.setBreakpoint(
+          bp.get("location").toJS(),
+          bp.get("condition")
         );
-        const [response, bpClient] = yield sourceClient.setBreakpoint({
-          line: bp.getIn(["location", "line"]),
-          column: bp.getIn(["location", "column"]),
-          condition: bp.get("condition")
-        });
 
         const { isPending, actualLocation } = response;
 

--- a/public/js/actions/sources.js
+++ b/public/js/actions/sources.js
@@ -172,8 +172,6 @@ function loadSourceText(source) {
       return promise.resolve(textInfo);
     }
 
-    const sourceClient = threadClient.source(source);
-
     return dispatch({
       type: constants.LOAD_SOURCE_TEXT,
       source: source,
@@ -185,17 +183,17 @@ function loadSourceText(source) {
         // let histogram = Services.telemetry.getHistogramById(histogramId);
         // let startTime = Date.now();
 
-        const response = yield sourceClient.source(() => {});
+        const response = yield threadClient.sourceContents(source.id);
 
         // histogram.add(Date.now() - startTime);
 
         // Automatically pretty print if enabled and the test is
         // detected to be "minified"
-        if (Prefs.autoPrettyPrint &&
-            !source.isPrettyPrinted &&
-            SourceUtils.isMinified(source.id, response.source)) {
-          dispatch(togglePrettyPrint(source));
-        }
+        // if (Prefs.autoPrettyPrint &&
+        //     !source.isPrettyPrinted &&
+        //     SourceUtils.isMinified(source.id, response.source)) {
+        //   dispatch(togglePrettyPrint(source));
+        // }
 
         return { text: response.source,
                  contentType: response.contentType };

--- a/public/js/actions/tests/loadSourceText.js
+++ b/public/js/actions/tests/loadSourceText.js
@@ -20,14 +20,10 @@ const sourceText = {
  * done state matters.
  */
 const simpleMockThreadClient = {
-  source: function(form) {
-    return {
-      source: () => {
-        return new Promise((resolve, reject) => {
-          resolve(sourceText[form.id]);
-        });
-      }
-    };
+  sourceContents: function(sourceId) {
+    return new Promise(resolve => {
+      resolve(sourceText[sourceId]);
+    });
   }
 };
 
@@ -37,14 +33,10 @@ const simpleMockThreadClient = {
  */
 const deferredMockThreadClient = {
   request: undefined,
-  source: function(form) {
-    return {
-      source: () => {
-        let deferred = promise.defer();
-        this.request = deferred;
-        return deferred.promise;
-      }
-    };
+  sourceContents: function(sourceId) {
+    let deferred = promise.defer();
+    this.request = deferred;
+    return deferred.promise;
   },
   getRequest: function() {
     return this.request;

--- a/public/js/actions/tests/selectSource.js
+++ b/public/js/actions/tests/selectSource.js
@@ -10,14 +10,10 @@ const { selectSource } = actions;
 const sourcesFixtures = fixtures.sources;
 
 const simpleMockThreadClient = {
-  source: function(form) {
-    return {
-      source: () => {
-        return new Promise((resolve, reject) => {
-          resolve(sourcesFixtures.sources[form.id]);
-        });
-      }
-    };
+  source: function(sourceId) {
+    return new Promise((resolve, reject) => {
+      resolve(sourcesFixtures.sources[sourceId]);
+    });
   }
 };
 

--- a/public/js/clients/index.js
+++ b/public/js/clients/index.js
@@ -1,31 +1,29 @@
 "use strict";
 
-const {
-  connectThread,
-  initPage,
-  getThreadClient: getFirefoxThreadClient
-} = require("./firefox");
-const {
-  debugChromeTab,
-  ThreadClient: ChromeThreadClient
-} = require("./chrome");
+const { Task } = require("ff-devtools-libs/sham/task");
+const firefox = require("./firefox");
+const chrome = require("./chrome");
 const { getSelectedTab } = require("../selectors");
 
 function getBrowserClient(state) {
   if (getSelectedTab(state).get("browser") === "chrome") {
-    return ChromeThreadClient;
+    return chrome.getAPIClient();
   }
 
-  return getFirefoxThreadClient();
+  return firefox.getAPIClient();
 }
 
 function debugPage(tab, actions) {
-  const isFirefox = tab.get("browser") == "firefox";
-  if (isFirefox) {
-    return connectThread(tab.get("tab")).then(() => initPage(actions));
-  }
-
-  return debugChromeTab(tab.get("tab"), actions);
+  return Task.spawn(function* () {
+    const isFirefox = tab.get("browser") == "firefox";
+    if (isFirefox) {
+      yield firefox.connectTab(tab.get("tab"));
+      firefox.initPage(actions);
+    } else {
+      yield chrome.connectTab(tab.get("tab"));
+      chrome.initPage(actions);
+    }
+  });
 }
 
 module.exports = {

--- a/public/js/types.js
+++ b/public/js/types.js
@@ -7,7 +7,7 @@ const Source = t.struct({
   url: t.union([t.String, t.Nil]),
 
   // Internal for Firefox for now
-  actor: t.String
+  actor: t.maybe(t.String)
 }, "Source");
 
 const Location = t.struct({


### PR DESCRIPTION
I'm already running into several situations where I need to wrap the Firefox protocol to translate something because we changed actors to ids. I think we need to go ahead and create a base API implementation for talking with servers.

This nice thing is that we don't have to deal with client/server communication at all. All we need is a simple programmatic API to talk about debugger data. I don't think we should do it the object-oriented way like the Firefox `main.js` currently is. I suppose eventually we may want to group these functions into separate namespaces, but I'd like them to stay simple functions that take ids on which to operate (for example, `sourceContents` takes a `sourceId`).

I also tweaked `chrome.js` to consolidate the APIs for the client modules into something more similar. This looks like a lot of changes, but it's not too bad, and I'm more than happy to discuss naming conventions, where to put things, etc.