### PR TITLE
Fixes issue where chrome tabs are not shown when firefox is not connected

### DIFF
--- a/public/js/clients/chrome.js
+++ b/public/js/clients/chrome.js
@@ -45,7 +45,7 @@ function formatTabs(tabs) {
     });
 }
 
-function chromeTabs() {
+function connectClient() {
   if (!isEnabled("chrome.debug")) {
     return Promise.resolve([]);
   }
@@ -188,7 +188,7 @@ function debugChromeTab(tab, actions) {
 }
 
 module.exports = {
-  chromeTabs,
+  connectClient,
   debugChromeTab,
   getAgent,
   ThreadClient

--- a/public/js/clients/firefox.js
+++ b/public/js/clients/firefox.js
@@ -3,6 +3,8 @@
 const { DebuggerClient } = require("ff-devtools-libs/shared/client/main");
 const { DebuggerTransport } = require("ff-devtools-libs/transport/transport");
 const { TargetFactory } = require("ff-devtools-libs/client/framework/target");
+const defer = require("../util/defer");
+
 let currentClient = null;
 let currentThreadClient = null;
 let currentTabTarget = null;
@@ -40,16 +42,34 @@ function presentTabs(tabs) {
   });
 }
 
-function connectClient(onConnect) {
+function connectClient() {
+  const deferred = defer();
+  let isConnected = false;
+
   const socket = new WebSocket("ws://localhost:9000");
   const transport = new DebuggerTransport(socket);
   currentClient = new DebuggerClient(transport);
 
+  // TODO: the timeout logic should be moved to DebuggerClient.connect.
+  setTimeout(() => {
+    if (isConnected) {
+      return;
+    }
+
+    deferred.resolve([]);
+  }, 1000);
+
   currentClient.connect().then(() => {
+    isConnected = true;
     return currentClient.listTabs().then(response => {
-      onConnect(presentTabs(response.tabs));
+      deferred.resolve(presentTabs(response.tabs));
     });
-  }).catch(err => console.log(err));
+  }).catch(err => {
+    console.log(err);
+    deferred.reject();
+  });
+
+  return deferred.promise;
 }
 
 function connectThread(tab, onNavigate) {

--- a/public/js/clients/index.js
+++ b/public/js/clients/index.js
@@ -3,11 +3,13 @@
 const {
   connectThread,
   initPage,
-  getThreadClient: getFirefoxThreadClient
+  getThreadClient: getFirefoxThreadClient,
+  connectClient: connectFirefoxClient
 } = require("./firefox");
 const {
   debugChromeTab,
-  ThreadClient: ChromeThreadClient
+  ThreadClient: ChromeThreadClient,
+  connectClient: connectChromeClient
 } = require("./chrome");
 const { getSelectedTab } = require("../selectors");
 
@@ -28,7 +30,18 @@ function debugPage(tab, actions) {
   return debugChromeTab(tab.get("tab"), actions);
 }
 
+function connectClients() {
+  return Promise.all([
+    connectFirefoxClient(),
+    connectChromeClient()
+  ]).then(results => {
+    const [firefoxTabs, chromeTabs] = results;
+    return firefoxTabs.concat(chromeTabs);
+  });
+}
+
 module.exports = {
   getBrowserClient,
+  connectClients,
   debugPage
 };

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -22,12 +22,10 @@ if (isEnabled("development")) {
 const configureStore = require("./create-store");
 const reducers = require("./reducers");
 const {
-  connectClient,
   setThreadClient, setTabTarget, initPage
 } = require("./clients/firefox");
 
-const { chromeTabs } = require("./clients/chrome");
-const { getBrowserClient, debugPage } = require("./clients");
+const { getBrowserClient, connectClients, debugPage } = require("./clients");
 
 const TabList = React.createFactory(require("./components/TabList"));
 
@@ -92,8 +90,8 @@ function renderToolbox() {
 }
 
 if (process.env.NODE_ENV !== "DEVTOOLS_PANEL") {
-  Promise.all([connectClient(), chromeTabs()]).then((tabs) => {
-    actions.newTabs(tabs[0].concat(tabs[1]));
+  connectClients().then((tabs) => {
+    actions.newTabs(tabs);
     renderNotConnected();
 
     // if there's a pre-selected tab, connect to it and load the sources.

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -67,7 +67,7 @@ function getTabFromUri(state) {
   return tabs.get(id);
 }
 
-setTimeout(function() {
+function renderNotConnected() {
   if (!getTabs(store.getState()).isEmpty()) {
     return;
   }
@@ -76,8 +76,9 @@ setTimeout(function() {
     React.DOM.div({ className: "not-connected-message" },
       "Not connected to Firefox"
     ),
-    document.querySelector("#mount"));
-}, 500);
+    document.querySelector("#mount")
+  );
+}
 
 function renderToolbox() {
   ReactDOM.render(
@@ -91,8 +92,9 @@ function renderToolbox() {
 }
 
 if (process.env.NODE_ENV !== "DEVTOOLS_PANEL") {
-  connectClient(tabs => {
-    actions.newTabs(tabs);
+  Promise.all([connectClient(), chromeTabs()]).then((tabs) => {
+    actions.newTabs(tabs[0].concat(tabs[1]));
+    renderNotConnected();
 
     // if there's a pre-selected tab, connect to it and load the sources.
     // otherwise, just show the toolbox.
@@ -104,12 +106,6 @@ if (process.env.NODE_ENV !== "DEVTOOLS_PANEL") {
       renderToolbox();
     }
   });
-
-  if (isEnabled("chrome.debug")) {
-    chromeTabs(response => {
-      actions.newTabs(response);
-    });
-  }
 } else {
   // The toolbox already provides the tab to debug. For now, just
   // provide a fake tab so it will show the debugger. We only use it

--- a/public/js/util/defer.js
+++ b/public/js/util/defer.js
@@ -1,0 +1,16 @@
+"use strict";
+
+function defer() {
+  let resolve, reject;
+  const promise = new Promise(function() {
+    resolve = arguments[0];
+    reject = arguments[1];
+  });
+  return {
+    resolve: resolve,
+    reject: reject,
+    promise: promise
+  };
+}
+
+module.exports = defer;


### PR DESCRIPTION
Fixes #187

I started working on running the integration tests with chrome, but before I could start I first needed to fix this issue. Sharing the PR early for feedback, if you like it i can take the chrome driver work out and merge. Then move to the chrome driver work later.

+ Update firefox.connectClient to handle timing out when firefox is not
connected
+ move the chrome.chromeTabs query up to connectClient so the two
queries are issued in tandem

Also sharing because this might conflict with some of your work with the api clients