### PR TITLE
fix locations of chrome breakpoints and improve debug line

### DIFF
--- a/public/js/actions/pause.js
+++ b/public/js/actions/pause.js
@@ -20,7 +20,12 @@ function resumed() {
  */
 function paused(pauseInfo) {
   return ({ dispatch, getState, client }) => {
-    dispatch(selectSource(pauseInfo.frame.location.sourceId));
+    const { location } = pauseInfo.frame;
+
+    dispatch(selectSource(location.sourceId, {
+      line: location.line
+    }));
+
     dispatch({
       type: constants.PAUSED,
       pauseInfo: pauseInfo

--- a/public/js/clients/chrome.js
+++ b/public/js/clients/chrome.js
@@ -50,7 +50,7 @@ let APIClient = {
   setBreakpoint(location, condition) {
     return debuggerAgent.setBreakpoint({
       scriptId: location.sourceId,
-      lineNumber: location.line,
+      lineNumber: location.line - 1,
       columnNumber: location.column
     }, (_, breakpointId, actualLocation) => ([
       {},
@@ -134,9 +134,9 @@ function makeDispatcher(actions) {
           id: frame.callFrameId,
           displayName: frame.functionName,
           location: Location({
-            sourceId: frame.functionLocation.scriptId,
-            line: frame.functionLocation.lineNumber + 1,
-            column: frame.functionLocation.columnNumber
+            sourceId: frame.location.scriptId,
+            line: frame.location.lineNumber + 1,
+            column: frame.location.columnNumber
           })
         });
       });

--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -8,7 +8,7 @@ const CodeMirror = require("codemirror");
 const { DOM: dom, PropTypes } = React;
 
 const {
-  getSourceText, getPause, getBreakpointsForSource,
+  getSourceText, getBreakpointsForSource,
   getSelectedSource, getSelectedSourceOpts,
   makeLocationId
 } = require("../selectors");
@@ -100,12 +100,6 @@ const Editor = React.createClass({
       this.setSourceText(nextProps.sourceText, this.props.sourceText);
     }
 
-    let pause = this.props.pause;
-
-    if (pause) {
-      this.clearDebugLine(pause.getIn(["frame", "location", "line"]));
-    }
-
     if (this.props.selectedSourceOpts &&
         this.props.selectedSourceOpts.get("line")) {
       this.clearDebugLine(this.props.selectedSourceOpts.get("line"));
@@ -114,9 +108,6 @@ const Editor = React.createClass({
     if (nextProps.selectedSourceOpts &&
         nextProps.selectedSourceOpts.get("line")) {
       this.setDebugLine(nextProps.selectedSourceOpts.get("line"));
-    } else if (nextProps.pause &&
-               !nextProps.pause.get("isInterrupted")) {
-      this.setDebugLine(nextProps.pause.getIn(["frame", "location", "line"]));
     }
   },
 
@@ -152,8 +143,7 @@ module.exports = connect(
       selectedSource: selectedSource,
       selectedSourceOpts: getSelectedSourceOpts(state),
       sourceText: getSourceText(state, selectedId),
-      breakpoints: getBreakpointsForSource(state, selectedId),
-      pause: getPause(state)
+      breakpoints: getBreakpointsForSource(state, selectedId)
     };
   },
   dispatch => bindActionCreators(actions, dispatch)


### PR DESCRIPTION
I feel like doing some polish work today :)

Chrome expects 0-based line locations everywhere. We use 1-based lines. Not only were we using `functionLocation` instead of `location`, but we were setting breakpoints on the wrong line (we should be setting them on `line - 1`).

This makes Chrome debugging work as expected.