### PR TITLE
make the editor highlighted line much more robust and remove selectedSourceOpts

### DIFF
--- a/public/js/actions/pause.js
+++ b/public/js/actions/pause.js
@@ -22,9 +22,7 @@ function paused(pauseInfo) {
   return ({ dispatch, getState, client }) => {
     const { location } = pauseInfo.frame;
 
-    dispatch(selectSource(location.sourceId, {
-      line: location.line
-    }));
+    dispatch(selectSource(location.sourceId));
 
     dispatch({
       type: constants.PAUSED,

--- a/public/js/actions/sources.js
+++ b/public/js/actions/sources.js
@@ -40,8 +40,7 @@ function selectSource(id, opts) {
 
     dispatch({
       type: constants.SELECT_SOURCE,
-      source: source,
-      opts: opts
+      source: source
     });
   };
 }

--- a/public/js/reducers/pause.js
+++ b/public/js/reducers/pause.js
@@ -17,14 +17,19 @@ function update(state = initialState, action, emit) {
   switch (action.type) {
     case constants.PAUSED:
       const pause = action.pauseInfo;
-      pause.isInterrupted = pause.why.type == "interrupted";
-      return state
-        .set("isWaitingOnBreak", false)
-        .set("pause", fromJS(pause));
+      pause.isInterrupted = pause.why.type === "interrupted";
+
+      return state.merge({
+        isWaitingOnBreak: false,
+        pause: fromJS(pause),
+        selectedFrame: action.pauseInfo.frame
+      });
     case constants.RESUME:
-      return state.merge({ pause: null,
-                           frames: null,
-                           selectedFrame: null });
+      return state.merge({
+        pause: null,
+        frames: null,
+        selectedFrame: null
+      });
     case constants.BREAK_ON_NEXT:
       return state.set("isWaitingOnBreak", true);
     case constants.LOADED_FRAMES:

--- a/public/js/reducers/sources.js
+++ b/public/js/reducers/sources.js
@@ -11,7 +11,6 @@ const initialState = fromJS({
   sources: {},
   sourceTree: ["root", []],
   selectedSource: null,
-  selectedSourceOpts: null,
   sourcesText: {}
 });
 
@@ -23,8 +22,7 @@ function update(state = initialState, action) {
 
     case constants.SELECT_SOURCE:
       return state.merge({
-        selectedSource: action.source,
-        selectedSourceOpts: action.opts
+        selectedSource: action.source
       });
 
     case constants.LOAD_SOURCE_TEXT: {


### PR DESCRIPTION
The editor must rely on some sort of paused state because if you switch to a file where the engine is paused, it needs to highlight the line that it is paused on. If can't only highlight the line the first time, and then switching away and back (via the source tree) not highlight the line again.

I also realized that we don't just want to highlight the line of the top frame. That's what we did before: highlight the line if the `pause.frame` (which is the top frame) has a location. But what if it's a file that is paused deeper in the stack?

Additionally, what if it's a file that has *multiple* stack entries? It's paused in several locations in that file.

I played around with Chrome and realized that they don't always highlight all the locations in the stack. They only highlight the "selected frame" location. We can easily do this by just checking if there is a selected frame. If so, and the frame source is the source we are showing, we highlight the line it is paused on. With this, switching away and back will always keep the line highlighted. And if you select other frames, that location will always be highlighted. Note that if you selected a deep frame and switch back to the file the originally paused (the top frame) it won't be highlighted anymore. That's because highlighting now directly represents the selected frame, which I think makes sense.

If we feel like we want a more "dumb" editor, we could easily split it out at some point and create a `DebuggerEditor` that does smart things like this. Right now I'm more interested in getting a solid editor for the debugger though. (And we'll probably deal with stuff like that when merging back into Firefox)

