### PR TITLE
make breakpoints more robust and improve protocol interface

### DIFF
--- a/public/js/components/Breakpoints.js
+++ b/public/js/components/Breakpoints.js
@@ -53,7 +53,7 @@ const Breakpoints = React.createClass({
   },
 
   renderBreakpoint(breakpoint) {
-    const snippet = breakpoint.getIn(["location", "snippet"]);
+    const snippet = breakpoint.get("text");
     const locationId = breakpoint.get("locationId");
     const line = breakpoint.getIn(["location", "line"]);
     const isCurrentlyPaused = breakpoint.get("isCurrentlyPaused");

--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -28,12 +28,14 @@ function isSourceForFrame(source, frame) {
 const Editor = React.createClass({
   propTypes: {
     breakpoints: ImPropTypes.map.isRequired,
-    selectedSource: ImPropTypes.map.isRequired,
+    selectedSource: ImPropTypes.map,
     sourceText: PropTypes.object,
     addBreakpoint: PropTypes.func,
     removeBreakpoint: PropTypes.func,
     selectedFrame: PropTypes.object
   },
+
+  displayName: "Editor",
 
   componentDidMount() {
     this.editor = CodeMirror.fromTextArea(this.refs.editor, {
@@ -58,12 +60,21 @@ const Editor = React.createClass({
       return b.getIn(["location", "line"]) === line + 1;
     });
 
-    const applyBp = bp ? this.props.removeBreakpoint : this.props.addBreakpoint;
-    applyBp({
-      sourceId: this.props.selectedSource.get("id"),
-      line: line + 1,
-      snippet: cm.lineInfo(line).text.trim()
-    });
+    if (bp) {
+      this.props.removeBreakpoint({
+        sourceId: this.props.selectedSource.get("id"),
+        line: line + 1
+      });
+    } else {
+      this.props.addBreakpoint(
+        { sourceId: this.props.selectedSource.get("id"),
+          line: line + 1 },
+        // Pass in a function to get line text because the breakpoint
+        // may slide and it needs to compute the value at the new
+        // line.
+        { getTextForLine: l => cm.getLine(l - 1).trim() }
+      );
+    }
   },
 
   clearDebugLine(line) {

--- a/public/js/types.js
+++ b/public/js/types.js
@@ -18,8 +18,21 @@ const Source = t.struct({
 const Location = t.struct({
   sourceId: t.String,
   line: t.Number,
-  column: t.Number
+  column: t.union([t.Number, t.Nil])
 }, "Location");
+
+const Breakpoint = t.struct({
+  id: t.String,
+  loading: t.Boolean,
+  disabled: t.Boolean,
+  text: t.String,
+  condition: t.union([t.String, t.Nil])
+});
+
+const BreakpointResult = t.struct({
+  id: t.String,
+  actualLocation: Location
+});
 
 const Frame = t.struct({
   id: t.String,
@@ -31,5 +44,7 @@ module.exports = {
   Tab,
   Source,
   Location,
+  Breakpoint,
+  BreakpointResult,
   Frame
 };


### PR DESCRIPTION
Breakpoints were pretty broken before: sliding breakpoints wouldn't work, and the data returned from each client was actually a bit different. I went ahead and improved the protocol so that "breakpoint clients" are only something the Firefox client has to be concerned with now. Breakpoints should be a lot more robust: sliding works, and adding & removing seems to always work now (previously sometimes I couldn't remove a breakpoint because it got into a bad state).

I also fixed "snippets" with sliding breakpoints: previously it would show "undefined" if the breakpoint moved. Now it properly gets the text from the line that it moved to.

r? 