### PR TITLE
Fix #230, stepOut icon now has lines along bottom

### DIFF
--- a/public/images/stepOut.svg
+++ b/public/images/stepOut.svg
@@ -1,8 +1,8 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-  <title>
-    debugger-step-out-expanded
-  </title>
   <g fill="#696969" fill-rule="evenodd">
-    <path d="M14.25 14.595V10.5a.5.5 0 0 0-1 0v4.095a.5.5 0 0 0 1 0zM14.25 5.595V1.5a.5.5 0 0 0-1 0v4.095a.5.5 0 0 0 1 0zM12 7.5a.498.498 0 0 1-.146.354l-4.5 4.5a.5.5 0 0 1-.708-.708L10.293 8H3.5v5.5a.5.5 0 1 1-1 0v-6a.5.5 0 0 1 .61-.488.427.427 0 0 1 .1-.012h7.083L6.646 3.354a.5.5 0 1 1 .708-.708l4.5 4.5A.498.498 0 0 1 12 7.5z"/>
+    <path d="M5 13.5H1a.5.5 0 1 0 0 1h4a.5.5 0 1 0 0-1zM12 13.5H8a.5.5 0 1 0 0 1h4a.5.5 0 1 0 0-1zM6.11 5.012A.427.427 0 0 1 6.21 5h7.083L9.646 1.354a.5.5 0 1 1 .708-.708l4.5 4.5a.498.498 0 0 1 0 .708l-4.5 4.5a.5.5 0 0 1-.708-.708L13.293 6H6.5v5.5a.5.5 0 1 1-1 0v-6a.5.5 0 0 1 .61-.488z"/>
   </g>
 </svg>


### PR DESCRIPTION
This is going to look fine on retina macs, but I'm going to file a follow-up bug to check that it's pixelsnapped on non-retina screens (can't check until I'm work with my other monitor).