### PR TITLE
Add more integration tests

### DIFF
--- a/mocha-runner.html
+++ b/mocha-runner.html
@@ -6,7 +6,6 @@
 </head>
 <body>
   <div id="mocha"></div>
-  <div id="sandbox"></div>
 
   <script src="https://cdn.rawgit.com/jquery/jquery/2.1.4/dist/jquery.min.js"></script>
   <script src="https://cdn.rawgit.com/Automattic/expect.js/0.3.1/index.js"></script>

--- a/public/js/actions/tests/loadSourceText.js
+++ b/public/js/actions/tests/loadSourceText.js
@@ -99,7 +99,7 @@ describe("loadSourceText", () => {
       store.dispatch(loadSourceText({ id: "foo1" }))
         .catch(() => deferred.resolve());
 
-      deferredMockThreadClient.getRequest().reject("poop");
+      deferredMockThreadClient.getRequest().reject("failed to load");
       return deferred.promise;
     }
 
@@ -108,7 +108,7 @@ describe("loadSourceText", () => {
     Task.spawn(function* () {
       yield loadBadSource(store);
       const fooSourceText = getSourceText(store.getState(), "foo1");
-      expect(fooSourceText.get("error")).to.equal("poop");
+      expect(fooSourceText.get("error")).to.equal("failed to load");
       done();
     });
   });

--- a/public/js/actions/tests/selectSource.js
+++ b/public/js/actions/tests/selectSource.js
@@ -35,8 +35,8 @@ describe("selectSource", () => {
       selectSource(sourcesFixtures.sources.fooSourceActor.id)
     );
 
-    const fooSourceText = getSelectedSource(this.store.getState());
-    expect(fooSourceText.get("id")).to.equal("fooSourceActor");
+    const fooSelectedSource = getSelectedSource(this.store.getState());
+    expect(fooSelectedSource.get("id")).to.equal("fooSourceActor");
   });
 
   it("selecting a source that hasn\'t been loaded", function() {
@@ -54,7 +54,7 @@ describe("selectSource", () => {
       selectSource(sourcesFixtures.sources.fooSourceActor.id)
     );
 
-    const fooSourceText = getSelectedSource(this.store.getState());
-    expect(fooSourceText.get("id")).to.equal("fooSourceActor");
+    const fooSelectedSource = getSelectedSource(this.store.getState());
+    expect(fooSelectedSource.get("id")).to.equal("fooSourceActor");
   });
 });

--- a/public/js/components/Accordion.js
+++ b/public/js/components/Accordion.js
@@ -37,7 +37,8 @@ const Accordion = React.createClass({
 
   renderContainer: function(item, i) {
     const { opened, created } = this.state;
-    const containerClassName = item.header.toLowerCase().replace(/\s/g, "-");
+    const containerClassName =
+          item.header.toLowerCase().replace(/\s/g, "-") + "-pane";
 
     return div(
       { className: containerClassName, key: i },

--- a/public/js/components/Breakpoints.css
+++ b/public/js/components/Breakpoints.css
@@ -1,4 +1,4 @@
-.breakpoints .breakpoint {
+.breakpoints-pane .breakpoint {
   font-size: 12px;
   list-style: none;
   color: var(--theme-content-color1);
@@ -6,15 +6,15 @@
   line-height: 1em;
 }
 
-.breakpoints .breakpoint:hover {
+.breakpoints-pane .breakpoint:hover {
   cursor: pointer;
   background-color: var(--theme-toolbar-background);
 }
 
-.breakpoints .breakpoint-label {
+.breakpoints-pane .breakpoint-label {
   display: inline-block;
 }
 
-.breakpoints .pause-indicator {
+.breakpoints-pane .pause-indicator {
   float: right;
 }

--- a/public/js/components/Breakpoints.js
+++ b/public/js/components/Breakpoints.js
@@ -87,7 +87,7 @@ const Breakpoints = React.createClass({
   render() {
     const { breakpoints } = this.props;
     return dom.div(
-      { className: "breakpoints" },
+      { className: "breakpoints-list" },
       (breakpoints.size === 0 ?
        dom.div({ className: "pane-info" }, "No Breakpoints") :
        breakpoints.valueSeq().map(bp => {

--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -60,6 +60,7 @@ const Editor = React.createClass({
     );
 
     resizeBreakpointGutter(this.editor);
+    this.setSourceText(this.props.sourceText);
   },
 
   onGutterClick(cm, line, gutter, ev) {

--- a/public/js/components/RightSidebar.js
+++ b/public/js/components/RightSidebar.js
@@ -13,7 +13,7 @@ const Frames = React.createFactory(require("./Frames"));
 const Accordion = React.createFactory(require("./Accordion"));
 require("./RightSidebar.css");
 
-function debugBtn(onClick, type, className) {
+function debugBtn(onClick, type, className = "active") {
   className = `${type} ${className}`;
 
   return dom.span(

--- a/public/js/components/Scopes.js
+++ b/public/js/components/Scopes.js
@@ -158,7 +158,7 @@ const Scopes = React.createClass({
 
     const scopeTree = scopes ? tree : info("Scopes Unavailable");
     return dom.div(
-      { className: "scopes-pane" },
+      { className: "scopes-list" },
       (pauseInfo ? scopeTree : info("Not Paused"))
     );
   }

--- a/public/js/components/stories/Breakpoints.js
+++ b/public/js/components/stories/Breakpoints.js
@@ -1,49 +1,25 @@
 "use strict";
 
-const React = require("react");
-const { DOM: dom, createElement } = React;
-const { storiesOf } = require("@kadira/storybook");
-const { Provider } = require("react-redux");
-const { fromJS } = require("immutable");
-const { createStore } = require("./utils");
+const { DOM: dom, createElement, createFactory } = require("react");
+const { renderComponent, storiesOf } = require("./utils");
 
-const Breakpoints = React.createFactory(require("../Breakpoints"));
-const fixtures = require("../../test/fixtures/foobar.json");
+const Breakpoints = require("../Breakpoints");
 
-const fooSourceActor = fixtures.sources.sources.fooSourceActor;
-const barSourceActor = fixtures.sources.sources.barSourceActor;
-const fooBreakpointActor = fixtures.breakpoints.fooBreakpointActor;
-const barBreakpointActor = fixtures.breakpoints.barBreakpointActor;
+const style = {
+  width: "300px",
+  margin: "auto",
+  paddingTop: "100px" };
+
+const component =
+  dom.div({ className: "accordion" },
+    dom.div({ className: "_content" },
+      dom.div({ className: "breakpoints-pane" },
+        createElement(createFactory(Breakpoints)))));
+
+function renderBreakpoints(fixtureName) {
+  return renderComponent(component, fixtureName, { style });
+}
 
 storiesOf("Breakpoints", module)
-  .add("No Breakpoints", () => {
-    const store = createStore();
-    return renderBreakpoints(store);
-  })
-  .add("1 Domain", () => {
-    const store = createStore({
-      sources: fromJS({ sources: { fooSourceActor }}),
-      breakpoints: fromJS({ breakpoints: { fooBreakpointActor }})
-    });
-    return renderBreakpoints(store);
-  })
-  .add("2 Domains", () => {
-    const store = createStore({
-      sources: fromJS({ sources: { fooSourceActor, barSourceActor }}),
-      breakpoints: fromJS({
-        breakpoints: { fooBreakpointActor, barBreakpointActor }
-      })
-    });
-    return renderBreakpoints(store);
-  });
-
-function renderBreakpoints(store) {
-  return dom.div({ style: {
-    width: "300px",
-    margin: "auto",
-    paddingTop: "100px" }},
-    dom.div({ style: { border: "1px solid #ccc", padding: "20px" }},
-      createElement(Provider, { store }, Breakpoints())
-    )
-  );
-}
+  .add("No Breakpoints", () => renderBreakpoints("todomvc"))
+  .add("1 Breakpoint", () => renderBreakpoints("todomvcUpdateOnEnter"));

--- a/public/js/components/stories/Editor.js
+++ b/public/js/components/stories/Editor.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const { DOM: dom, createElement, createFactory } = require("react");
+const { renderComponent, storiesOf } = require("./utils");
+
+const Frames = require("../Editor");
+
+const style = {
+  width: "700px",
+  height: "600px",
+  position: "relative",
+  margin: "auto",
+  marginTop: "100px" };
+
+const component = createElement(createFactory(Frames));
+
+function renderEditor(fixtureName) {
+  return renderComponent(component, fixtureName, { style });
+}
+
+storiesOf("Editor", module)
+  .add("TodoMVC", () => renderEditor("todomvc"));

--- a/public/js/components/stories/Sources.js
+++ b/public/js/components/stories/Sources.js
@@ -1,54 +1,21 @@
 "use strict";
 const React = require("react");
-const { DOM: dom, createElement } = React;
-const { Provider } = require("react-redux");
-const { fromJS } = require("immutable");
+const { createElement, createFactory } = React;
+const { renderComponent, storiesOf } = require("./utils");
 
-const { createStore } = require("./utils");
+const Sources = require("../Sources");
 
-const { storiesOf } = require("@kadira/storybook");
+const style = {
+  width: "300px",
+  margin: "auto",
+  paddingTop: "100px" };
 
-const Sources = React.createFactory(require("../Sources"));
-const fixtures = require("../../test/fixtures");
+const component = createElement(createFactory(Sources));
 
-function sourceData(fixture) {
-  return fixtures[fixture].sources.sources;
+function renderSources(fixtureName) {
+  return renderComponent(component, fixtureName, { style });
 }
 
 storiesOf("Sources", module)
-  .add("Same Domain", () => {
-    const store = createStore({
-    });
-    const foobar = fixtures.foobar;
-    const fooSourceActor = foobar.sources.sources.fooSourceActor;
-    const barSourceActor = foobar.sources.sources.barSourceActor;
-    const props = {
-      sources: fromJS({ fooSourceActor, barSourceActor })
-    };
-
-    return renderContainer(store, Sources, props);
-  })
-  .add("TodoMVC", () => {
-    const sources = sourceData("todomvcUpdateOnEnter");
-    const store = createStore({
-      sources: fromJS({ selectedSource: sources["server1.conn8.child2/42"] })
-    });
-
-    const props = {
-      sources: fromJS(sources)
-    };
-
-    return renderContainer(store, Sources, props);
-  });
-
-function renderContainer(store, Component, props) {
-  return dom.div({ style: {
-    overflowX: "hidden",
-    width: "300px",
-    margin: "auto",
-    paddingTop: "100px" }},
-    dom.div({ style: { border: "1px solid #ccc" }},
-      createElement(Provider, { store }, Component(props))
-    )
-  );
-}
+  .add("TodoMVC", () => renderSources("todomvc"))
+  .add("Nested Closures", () => renderSources("pythagorean"));

--- a/public/js/components/stories/index.js
+++ b/public/js/components/stories/index.js
@@ -5,3 +5,4 @@ require("./Breakpoints");
 require("./Scopes");
 require("./Sources");
 require("./Frames");
+require("./Editor");

--- a/public/js/components/test-utils.js
+++ b/public/js/components/test-utils.js
@@ -8,10 +8,15 @@ const renderComponentFromFixture = require("../test/utils/renderComponentFromFix
 function getSandbox() {
   let $el = document.querySelector("#sandbox");
   if (!$el) {
-    const attribute = document.createAttribute("id");
-    attribute.nodeValue = "sandbox";
+    const idAttr = document.createAttribute("id");
+    idAttr.nodeValue = "sandbox";
+
+    const styleAttr = document.createAttribute("style");
+    styleAttr.nodeValue = "top: 0; position: relative; height: 500px;";
+
     $el = document.createElement("div");
-    $el.setAttributeNode(attribute);
+    $el.setAttributeNode(idAttr);
+    $el.setAttributeNode(styleAttr);
     document.body.appendChild($el);
   }
 

--- a/public/js/components/tests/Breakpoints.js
+++ b/public/js/components/tests/Breakpoints.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const Breakpoints = require("../Breakpoints");
+const { renderComponent } = require("../test-utils");
+
+function getBreakpoints($el) {
+  return $el.querySelector(".breakpoints-list").children;
+}
+
+function getBreakpointLabel($breakpoint) {
+  return $breakpoint.querySelector(".breakpoint-label").innerText;
+}
+
+describe("Breakpoint Component", function() {
+  it("Not Paused", function() {
+    if (typeof window != "object") {
+      return;
+    }
+
+    const $el = renderComponent(Breakpoints, "todomvc");
+    expect($el.innerText).to.equal("No Breakpoints");
+  });
+
+  it("1 Breakpoint", function() {
+    if (typeof window != "object") {
+      return;
+    }
+
+    const $el = renderComponent(Breakpoints, "todomvcUpdateOnEnter");
+    const breakpoints = getBreakpoints($el);
+    expect(breakpoints.length).to.equal(1);
+    expect(getBreakpointLabel(breakpoints[0])).to.equal("113 this.close();");
+  });
+});

--- a/public/js/components/tests/Editor.js
+++ b/public/js/components/tests/Editor.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const Editor = require("../Editor");
+const { renderComponent } = require("../test-utils");
+
+function getEditorLines($el) {
+  return $el.querySelectorAll(".codemirror-line");
+}
+
+describe("Editor", function() {
+  it("todomvc", function() {
+    if (typeof window != "object") {
+      return;
+    }
+
+    const $el = renderComponent(Editor, "todomvc");
+    const lines = getEditorLines($el);
+    expect(lines.length).to.equal(46);
+    expect(lines[2].innerText).to.equal("var app = app || {};");
+  });
+});

--- a/public/js/test/cypress/commands.js
+++ b/public/js/test/cypress/commands.js
@@ -46,6 +46,7 @@ Cypress.addParentCommand("debuggee", function(callback) {
 });
 
 Cypress.addParentCommand("navigate", function(url) {
+  url = "http://localhost:8000/" + url;
   return cy.window().then(win => {
     return win.apiClient.navigate(url);
   });

--- a/public/js/test/cypress/commands/debugger.js
+++ b/public/js/test/cypress/commands/debugger.js
@@ -1,3 +1,37 @@
+/**
+ DOM selectors
+*/
+
+function callStackPane() {
+  return cy.get(".call-stack-pane");
+}
+
+function callStackFrameAtIndex(index) {
+  return callStackPane().find(".frames .frame").eq(index);
+}
+
+function breakpointPane() {
+  return cy.get(".breakpoints-pane .breakpoints-list");
+}
+
+function breakpointAtIndex(index) {
+  return breakpointPane().find(".breakpoint").eq(index);
+}
+
+function commandBar() {
+  return cy.get(".command-bar");
+}
+
+function scopesPane() {
+  return cy.get(".scopes-pane");
+}
+
+function scopeAtIndex(index) {
+  return scopesPane().find(".scopes-list > .tree").children().eq(index);
+}
+/**
+  DOM commands
+*/
 
 /**
   1. load the debugger and connect to the first chrome or firefox tab
@@ -7,11 +41,12 @@
   the test delays are safeguards for the timebeing, but they should
   be able to be removed if the test waits for the elements to appear.
  */
-function debugPage(url, browser = "Firefox") {
+function debugPage(urlPart, browser = "Firefox") {
+  url = "http://localhost:8000/" + urlPart;
   cy.visit("http://localhost:8000");
   cy.get(`.${browser} .tab`).first().click();
   cy.wait(1000);
-  cy.navigate(url);
+  cy.navigate(urlPart);
   cy.wait(1000);
   cy.reload();
   cy.wait(1000);
@@ -40,23 +75,69 @@ function toggleBreakpoint(linenumber) {
     .contains(".CodeMirror-linenumber", linenumber).click();
 }
 
+function selectBreakpointInList(index) {
+  breakpointAtIndex(index).click();
+}
+
+function toggleBreakpointInList(index) {
+  breakpointAtIndex(index).find("input[type='checkbox']").click();
+}
+
 function toggleCallStack() {
-  cy.get(".call-stack").find("._header").click();
+  callStackPane().find("._header").click();
 }
 
-function hasCallStackFrame(frame) {
-  return cy.get(".call-stack").contains(".frames .frame", frame);
+function selectCallStackFrame(index) {
+  callStackFrameAtIndex(index).click();
 }
 
-function resumeDebugger() {
-  cy.get(".right-sidebar").find(".resume").click();
+function toggleScopes() {
+  scopesPane().find("._header").click();
+}
+
+function selectScope(index) {
+  scopeAtIndex(index).find(".arrow").click();
+}
+
+function resume() {
+  commandBar().find(".active.resume").click();
+}
+
+function stepOver() {
+  commandBar().find(".active.stepOver").click();
+}
+
+function stepIn() {
+  commandBar().find(".active.stepIn").click();
+}
+
+function stepOut() {
+  commandBar().find(".active.stepOut").click();
+}
+
+
+/**
+ DOM queries
+*/
+
+function sourceTab(fileName) {
+  return cy.get(".source-tab");
 }
 
 Object.assign(window, {
   debugPage,
   goToSource,
   toggleBreakpoint,
+  selectBreakpointInList,
+  toggleBreakpointInList,
   toggleCallStack,
-  hasCallStackFrame,
-  resumeDebugger
+  callStackFrameAtIndex,
+  toggleScopes,
+  scopeAtIndex,
+  selectScope,
+  sourceTab,
+  resume,
+  stepIn,
+  stepOut,
+  stepOver
 })

--- a/public/js/test/cypress/commands/todomvc.js
+++ b/public/js/test/cypress/commands/todomvc.js
@@ -1,21 +1,21 @@
 function addTodo() {
   cy.debuggee(() => {
-    window.Debuggee.type("#new-todo", "hi");
-    window.Debuggee.type("#new-todo", "{enter}");
+    dbg.type("#new-todo", "hi");
+    dbg.type("#new-todo", "{enter}");
   });
 }
 
 function editTodo() {
   cy.debuggee(() => {
-    window.Debuggee.dblclick("#todo-list li label");
-    window.Debuggee.type("#todo-list li .edit", "there");
-    window.Debuggee.type("#todo-list li .edit", "{enter}");
+    dbg.dblclick("#todo-list li label");
+    dbg.type("#todo-list li .edit", "there");
+    dbg.type("#todo-list li .edit", "{enter}");
   });
 }
 
 function toggleTodo() {
   cy.debuggee(() => {
-    window.Debuggee.click("#todo-list li .toggle");
+    dbg.click("#todo-list li .toggle");
   });
 }
 
@@ -23,4 +23,4 @@ Object.assign(window, {
   addTodo,
   editTodo,
   toggleTodo
-})
+});

--- a/public/js/test/fixtures/foobar.json
+++ b/public/js/test/fixtures/foobar.json
@@ -17,7 +17,11 @@
     "sourcesText": {
       "fooSourceActor": {
         "contentType": "text/javascript",
-        "text": "function() {\n  return 5;\n}"
+        "text": "function() {\n  return foo;\n}"
+      },
+      "barSourceActor": {
+        "contentType": "text/javascript",
+        "text": "function() {\n  return bar;\n}"
       }
     }
   },

--- a/public/js/test/integration/fixtures.js
+++ b/public/js/test/integration/fixtures.js
@@ -1,7 +1,6 @@
 // turn theses tests on when you want to write new fixture data
 // you also need to turn on the cypress-server to be able to save the fixtures.
 xdescribe("Fixtures", function() {
-  it("todomvc.updateOnEnter", function() {
   /**
    An example of the debugger not being paused.
    */
@@ -27,7 +26,7 @@ xdescribe("Fixtures", function() {
     cy.saveFixture("todomvc.updateOnEnter");
 
     // cleanup
-    resumeDebugger();
+    resume();
     toggleBreakpoint(113);
     cy.navigate("http://localhost:8000/todomvc");
   });
@@ -45,7 +44,7 @@ xdescribe("Fixtures", function() {
     cy.wait(1000);
     cy.saveFixture("pythagorean");
 
-    resumeDebugger();
+    resume();
     toggleBreakpoint(11);
     cy.navigate("http://localhost:8000/pythagorean");
   })

--- a/public/js/test/integration/todomvc.js
+++ b/public/js/test/integration/todomvc.js
@@ -2,30 +2,81 @@
 
 describe("Todo MVC", function() {
   it("(Firefox) Adding a Todo", function() {
-    debugPage("http://localhost:8000/todomvc");
+    debugPage("todomvc");
     goToSource("js/views/todo-view");
     toggleBreakpoint(33);
 
+    // pause and check the first frame
     addTodo();
-
     toggleCallStack();
-    hasCallStackFrame("initialize");
-    resumeDebugger();
+    toggleScopes();
+    callStackFrameAtIndex(0).contains("initialize");
+
+    // select the second frame and check to see the source updated
+    selectCallStackFrame(1);
+    sourceTab().contains("backbone.js");
+
+    // step into the initialize function
+    // and expand the Events[method] scope
+    stepIn();
+    selectScope(0)
+    stepOver();
+    stepOut();
+    resume();
+
     toggleBreakpoint(33);
-    cy.navigate("http://localhost:8000/todomvc");
+    cy.navigate("todomvc");
   });
 
-  xit("(Chrome) Adding a Todo", function() {
-    debugPage("http://localhost:8000/todomvc", "Chrome");
+  it("(Firefox) Adding Breakpoints", function() {
+    debugPage("todomvc");
+
+    // test adding breakpoints
     goToSource("js/views/todo-view");
     toggleBreakpoint(33);
-    addTodo();
-    toggleCallStack();
-    hasCallStackFrame("initialize");
+    goToSource("app-view");
+    toggleBreakpoint(35);
+
+    // test navigating to a source by selecting a breakpoint
+    selectBreakpointInList(0);
+    sourceTab().contains("todo-view.js")
+
+    // test enabling/disabling breakpoints
+    toggleBreakpointInList(0);
+    toggleBreakpointInList(0);
 
     // cleanup
-    resumeDebugger();
+    toggleBreakpoint(35);
+    goToSource("todo-view");
     toggleBreakpoint(33);
-    cy.navigate("http://localhost:8000/todomvc");
+    cy.navigate("todomvc");
+  });
+
+  // this is a simple test that will test the Chrome
+  // client. At some point we will replace it with a
+  // mocha macro `withBrowsers("chrome", "firefox", function() {})`
+  // that will wrap these tests call each `it` in both browser contexts.
+  xit("(Chrome) Adding a Todo", function() {
+    debugPage("todomvc", "Chrome");
+    goToSource("js/views/todo-view");
+    toggleBreakpoint(33);
+
+    // pause and check the first frame
+    addTodo();
+    toggleCallStack();
+    toggleScopes();
+    callStackFrameAtIndex(0).contains("initialize");
+
+    // select the second frame and check to see the source updated
+    selectCallStackFrame(1);
+    sourceTab().contains("backbone.js");
+
+    stepIn();
+    stepOver();
+    stepOut();
+    resume();
+
+    toggleBreakpoint(33);
+    cy.navigate("todomvc");
   });
 });

--- a/public/js/test/utils/debuggee.js
+++ b/public/js/test/utils/debuggee.js
@@ -106,7 +106,7 @@ function Debuggee() {
   };
 }
 
-const debuggeeStatement = `window.Debuggee = (${Debuggee})()`;
+const debuggeeStatement = `window.dbg = (${Debuggee})()`;
 let injectedDebuggee;
 
 function injectDebuggee() {

--- a/public/js/test/utils/renderComponentFromFixture.js
+++ b/public/js/test/utils/renderComponentFromFixture.js
@@ -23,7 +23,12 @@ function getData(fixtureName) {
       frames: fixture.pause.frames
     }),
     sources: Map({
-      sources: fromJS(fixture.sources.sources)
+      sources: fromJS(fixture.sources.sources),
+      selectedSource: fromJS(fixture.sources.selectedSource),
+      sourcesText: fromJS(fixture.sources.sourcesText)
+    }),
+    breakpoints: Map({
+      breakpoints: fromJS(fixture.breakpoints.breakpoints)
     })
   };
 }


### PR DESCRIPTION
Adds several more steps to the integration tests:
+ enabling / disabling breakpoints
+ selecting a breakpoint (for source navigational purposes)
+ selecting a scope
+ step in, out, over ...

As I went, I refactored the debugger commands so that common selectors
were re-used to avoid painful test refactoring when the UI changes.

Writing the tests were actually pretty fun. Surprising/Unsuprisingly,
there were no hiccups along the way.

I cleaned up some of the CSS as I went so that the class names were
clearer.