### PR TITLE
More config tweaks

### DIFF
--- a/config/feature.js
+++ b/config/feature.js
@@ -1,8 +1,5 @@
 "use strict";
 
-const DevToolsUtils = require("devtools-sham/shared/DevToolsUtils");
-const AppConstants = require("devtools-sham/sham/appconstants").AppConstants;
-
 let config = {};
 
 const developmentConfig = require("./development.json");
@@ -46,50 +43,15 @@ function isDevelopment() {
   return isEnabled("development");
 }
 
-function isDevToolsPanel() {
-  return process.env.NODE_ENV === "DEVTOOLS_PANEL";
-}
-
 function getPath(path, parentObj) {
   const keys = path.split(".");
   return keys.reduce((obj, key) => obj[key], parentObj);
 }
 
-function getTargetFromQuery() {
-  const href = window.location.href;
-  const nodeMatch = href.match(/ws=([^&#]*)/);
-  const firefoxMatch = href.match(/firefox-tab=([^&#]*)/);
-  const chromeMatch = href.match(/chrome-tab=([^&#]*)/);
-
-  if (nodeMatch) {
-    return { type: "node", param: nodeMatch[1] };
-  } else if (firefoxMatch) {
-    return { type: "firefox", param: firefoxMatch[1] };
-  } else if (chromeMatch) {
-    return { type: "chrome", param: chromeMatch[1] };
-  }
-
-  return null;
-}
-
-function setConfigs() {
-  // Set various flags before requiring app code.
-  if (isEnabled("clientLogging")) {
-    DevToolsUtils.dumpn.wantLogging = true;
-  }
-
-  if (isEnabled("development")) {
-    AppConstants.DEBUG_JS_MODULES = true;
-  }
-}
-
 module.exports = {
   isEnabled,
   getValue,
-  getTargetFromQuery,
-  setConfigs,
   isDevelopment,
-  isDevToolsPanel,
   setConfig,
   getConfig
 };


### PR DESCRIPTION
This is the last tweak to configs that I'm going to make. Jason, we can talk about this when you get back.

It feels weird to me that the configs should know about how to parse query strings and stuff like that. That is solely part of the initialization process, and I really like that new developers can just open up `main.js`, read it from top to bottom, and see exactly how it works without having to dig into other abstractions.

I see the config system as mostly server-side. As mentioned in another PR, the client should be given a set of flags somehow that just tweaks a few things (are sourcemaps enabled, etc). When we integrate with Firefox, we'll use it's pref system to hand the client its configs.

Definitely something we'll talk more about when you get back!