### PR TITLE
consolidate webpack dev/prod config into webpack.config.js

### DIFF
--- a/bin/development-server.js
+++ b/bin/development-server.js
@@ -24,8 +24,6 @@ if(!fs.existsSync(localConfigPath)) {
 
 const features = require("../config/feature");
 
-const projectConfig = require("../webpack.config");
-
 require("./firefox-proxy");
 
 function httpGet(url, onResponse) {
@@ -44,27 +42,7 @@ const app = express();
 
 // Webpack middleware
 
-const hotReloadingEnabled = features.getValue("hotReloading");
-
-const config = Object.assign({}, projectConfig, {
-  entry: [path.join(__dirname, "../public/js/main.js")]
-});
-
-if(hotReloadingEnabled) {
-  config.entry.push("webpack-hot-middleware/client");
-
-  config.plugins = config.plugins.concat([
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
-  ]);
-
-  config.module.loaders.push({
-    test: /\.js$/,
-    include: path.join(__dirname, "../public/js"),
-    loader: "react-hot"
-  });
-}
-
+const config = require("../webpack.config");
 const compiler = webpack(config);
 
 app.use(webpackDevMiddleware(compiler, {
@@ -72,7 +50,10 @@ app.use(webpackDevMiddleware(compiler, {
   noInfo: true,
   stats: { colors: true }
 }));
-app.use(webpackHotMiddleware(compiler));
+
+if(features.isEnabled("hotReloading")) {
+  app.use(webpackHotMiddleware(compiler));
+}
 
 // Static middleware
 

--- a/public/js/components/Sources.css
+++ b/public/js/components/Sources.css
@@ -105,7 +105,6 @@ ul.sources-list {
   padding: 2px 5px;
   position: relative;
   cursor: pointer;
-  transition: all 0.1s ease;
 }
 
 .tree .node:hover {

--- a/public/js/components/SourcesTree.js
+++ b/public/js/components/SourcesTree.js
@@ -14,10 +14,10 @@ const Arrow = React.createFactory(require("./util/Arrow"));
 const { Set } = require("immutable");
 
 const ManagedTree = React.createFactory(require("./util/ManagedTree"));
-const FolderIcon = React.createFactory(require("./util/icons").FolderIcon);
-const DomainIcon = React.createFactory(require("./util/icons").DomainIcon);
-const FileIcon = React.createFactory(require("./util/icons").FileIcon);
-const WorkerIcon = React.createFactory(require("./util/icons").WorkerIcon);
+const FolderIcon = React.createFactory(require("./util/Icons").FolderIcon);
+const DomainIcon = React.createFactory(require("./util/Icons").DomainIcon);
+const FileIcon = React.createFactory(require("./util/Icons").FileIcon);
+const WorkerIcon = React.createFactory(require("./util/Icons").WorkerIcon);
 
 let SourcesTree = React.createClass({
   propTypes: {


### PR DESCRIPTION
This enables CSS hot reloading by not extracting CSS into a single file in dev mode. It also moves the hot reloading config from development-server.js where it didn't belong.