### PR TITLE
Style disabled breakpoints in the list

### DIFF
--- a/public/js/components/Breakpoints.css
+++ b/public/js/components/Breakpoints.css
@@ -6,6 +6,9 @@
   line-height: 1em;
 }
 
+.breakpoints-pane .breakpoint.paused {
+}
+
 .breakpoints-pane .breakpoint.disabled .breakpoint-label {
   color: var(--theme-content-color3);
   transition: color 0.5s linear;

--- a/public/js/components/Breakpoints.css
+++ b/public/js/components/Breakpoints.css
@@ -6,8 +6,10 @@
   line-height: 1em;
 }
 
+/*
 .breakpoints-pane .breakpoint.paused {
 }
+*/
 
 .breakpoints-pane .breakpoint.disabled .breakpoint-label {
   color: var(--theme-content-color3);

--- a/public/js/components/Breakpoints.css
+++ b/public/js/components/Breakpoints.css
@@ -6,6 +6,11 @@
   line-height: 1em;
 }
 
+.breakpoints-pane .breakpoint.disabled .breakpoint-label {
+  color: var(--theme-content-color3);
+  transition: color 0.5s linear;
+}
+
 .breakpoints-pane .breakpoint:hover {
   cursor: pointer;
   background-color: var(--theme-toolbar-background);

--- a/public/js/components/Breakpoints.js
+++ b/public/js/components/Breakpoints.js
@@ -5,6 +5,7 @@ const { connect } = require("react-redux");
 const { bindActionCreators } = require("redux");
 const ImPropTypes = require("react-immutable-proptypes");
 const Isvg = React.createFactory(require("react-inlinesvg"));
+const classnames = require("classnames");
 const actions = require("../actions");
 const { getSource, getPause, getBreakpoints, makeLocationId } = require("../selectors");
 const { truncateStr } = require("../util/utils");
@@ -58,6 +59,7 @@ const Breakpoints = React.createClass({
     const locationId = breakpoint.get("locationId");
     const line = breakpoint.getIn(["location", "line"]);
     const isCurrentlyPaused = breakpoint.get("isCurrentlyPaused");
+    const isDisabled = breakpoint.get("disabled");
 
     const isPausedIcon = isCurrentlyPaused && Isvg({
       className: "pause-indicator",
@@ -66,14 +68,17 @@ const Breakpoints = React.createClass({
 
     return dom.div(
       {
-        className: "breakpoint",
+        className: classnames({
+          breakpoint: true,
+          disabled: isDisabled
+        }),
         key: locationId,
         onClick: () => this.selectBreakpoint(breakpoint)
       },
       dom.input(
         {
           type: "checkbox",
-          checked: !breakpoint.get("disabled"),
+          checked: !isDisabled,
           onChange: () => this.handleCheckbox(breakpoint)
         }),
       dom.div(

--- a/public/js/components/Breakpoints.js
+++ b/public/js/components/Breakpoints.js
@@ -69,7 +69,7 @@ const Breakpoints = React.createClass({
     return dom.div(
       {
         className: classnames({
-          breakpoint: true,
+          breakpoint,
           paused: isCurrentlyPaused,
           disabled: isDisabled
         }),

--- a/public/js/components/Breakpoints.js
+++ b/public/js/components/Breakpoints.js
@@ -70,6 +70,7 @@ const Breakpoints = React.createClass({
       {
         className: classnames({
           breakpoint: true,
+          paused: isCurrentlyPaused,
           disabled: isDisabled
         }),
         key: locationId,

--- a/public/js/components/stories/Breakpoints.js
+++ b/public/js/components/stories/Breakpoints.js
@@ -22,4 +22,4 @@ function renderBreakpoints(fixtureName) {
 
 storiesOf("Breakpoints", module)
   .add("No Breakpoints", () => renderBreakpoints("todomvc"))
-  .add("1 Breakpoint", () => renderBreakpoints("todomvcUpdateOnEnter"));
+  .add("3 Breakpoints", () => renderBreakpoints("todomvcUpdateOnEnter"));

--- a/public/js/components/tests/Breakpoints.js
+++ b/public/js/components/tests/Breakpoints.js
@@ -21,14 +21,18 @@ describe("Breakpoint Component", function() {
     expect($el.innerText).to.equal("No Breakpoints");
   });
 
-  it("1 Breakpoint", function() {
+  it("3 Breakpoints", function() {
     if (typeof window != "object") {
       return;
     }
 
     const $el = renderComponent(Breakpoints, "todomvcUpdateOnEnter");
     const breakpoints = getBreakpoints($el);
-    expect(breakpoints.length).to.equal(1);
+    expect(breakpoints.length).to.equal(3);
     expect(getBreakpointLabel(breakpoints[0])).to.equal("113 this.close();");
+    expect(getBreakpointLabel(breakpoints[1])).to
+    .equal("142 return undefined;");
+    expect(getBreakpointLabel(breakpoints[2])).to
+    .equal("169 var name = text.toLowerCase();");
   });
 });

--- a/public/js/components/tests/Breakpoints.js
+++ b/public/js/components/tests/Breakpoints.js
@@ -11,6 +11,10 @@ function getBreakpointLabel($breakpoint) {
   return $breakpoint.querySelector(".breakpoint-label").innerText;
 }
 
+function getBreakpointClasses($breakpoint) {
+  return Array.from($breakpoint.classList);
+}
+
 describe("Breakpoint Component", function() {
   it("Not Paused", function() {
     if (typeof window != "object") {
@@ -30,9 +34,11 @@ describe("Breakpoint Component", function() {
     const breakpoints = getBreakpoints($el);
     expect(breakpoints.length).to.equal(3);
     expect(getBreakpointLabel(breakpoints[0])).to.equal("113 this.close();");
+    expect(getBreakpointClasses(breakpoints[0])).to.contain("paused");
     expect(getBreakpointLabel(breakpoints[1])).to
-    .equal("142 return undefined;");
+      .equal("119 revertOnEscape: function (e) {");
     expect(getBreakpointLabel(breakpoints[2])).to
-    .equal("169 var name = text.toLowerCase();");
+      .equal("121 this.$el.removeClass('editing'...");
+    expect(getBreakpointClasses(breakpoints[2])).to.contain("disabled");
   });
 });

--- a/public/js/components/tests/Frames.js
+++ b/public/js/components/tests/Frames.js
@@ -32,7 +32,7 @@ describe("Frames", function() {
 
     const $el = renderComponent(Frames, "todomvcUpdateOnEnter");
     const frames = getFrames($el);
-    expect(frames.length).to.equal(3);
+    expect(frames.length).to.equal(6);
     expect(getFrameTitle(frames[0])).to.equal("app.TodoView<.updateOnEnter");
     expect(getFrameLocation(frames[0])).to.equal("todo-view.js");
   });
@@ -44,7 +44,7 @@ describe("Frames", function() {
 
     const $el = renderComponent(Frames, "pythagorean");
     const frames = getFrames($el);
-    expect(frames.length).to.equal(3);
+    expect(frames.length).to.equal(5);
     expect(getFrameTitle(frames[0])).to.equal("pythagorean");
     expect(getFrameLocation(frames[0])).to.equal("pythagorean.js");
   });

--- a/public/js/test/fixtures/pythagorean.json
+++ b/public/js/test/fixtures/pythagorean.json
@@ -6,20 +6,20 @@
   },
   "sources": {
     "sources": {
-      "server2.conn124.source36": {
-        "id": "server2.conn124.source36",
+      "server2.conn42.child1/28": {
+        "id": "server2.conn42.child1/28",
         "url": "http://localhost:8000/pythagorean/"
       },
-      "server2.conn124.source35": {
-        "id": "server2.conn124.source35",
+      "server2.conn42.child1/29": {
+        "id": "server2.conn42.child1/29",
         "url": "http://localhost:8000/pythagorean/pythagorean.js"
       },
-      "server2.conn124.source39": {
-        "id": "server2.conn124.source39",
+      "server2.conn42.child1/32": {
+        "id": "server2.conn42.child1/32",
         "url": null
       },
-      "server2.conn124.source44": {
-        "id": "server2.conn124.source44",
+      "server2.conn42.child1/37": {
+        "id": "server2.conn42.child1/37",
         "url": null
       }
     },
@@ -28,33 +28,33 @@
       []
     ],
     "selectedSource": {
-      "id": "server2.conn124.source35",
+      "id": "server2.conn42.child1/29",
       "url": "http://localhost:8000/pythagorean/pythagorean.js"
     },
     "sourcesText": {
-      "server2.conn124.source35": {
+      "server2.conn42.child1/29": {
         "text": "\"use strict\";\n\nfunction math(a, b) {\n  var bar = 4;\n  function pythagorean(a, b) {\n    var foo = 3;\n    function exponential(num) {\n      foo, bar;\n      return num * num;\n    }\n    return exponential(a) + exponential(b);\n  }\n\n  pythagorean(a,b);\n}\n",
         "contentType": "text/javascript"
       }
     },
     "tabs": [
       {
-        "id": "server2.conn124.source35",
+        "id": "server2.conn42.child1/29",
         "url": "http://localhost:8000/pythagorean/pythagorean.js"
       }
     ]
   },
   "breakpoints": {
     "breakpoints": {
-      "server2.conn124.source35:11": {
+      "server2.conn42.child1/29:11": {
         "location": {
-          "sourceId": "server2.conn124.source35",
+          "sourceId": "server2.conn42.child1/29",
           "line": 11
         },
         "condition": null,
         "disabled": false,
         "loading": false,
-        "id": "server2.conn124.38",
+        "id": "server2.conn42.child1/31",
         "text": "return exponential(a) + exponential(b);"
       }
     }
@@ -66,37 +66,37 @@
   },
   "pause": {
     "pause": {
-      "from": "server2.conn124.context33",
+      "from": "server2.conn42.child1/26",
       "type": "paused",
-      "actor": "server2.conn124.pause45",
+      "actor": "server2.conn42.child1/pause38",
       "frame": {
-        "id": "server2.conn124.46",
+        "id": "server2.conn42.child1/39",
         "displayName": "pythagorean",
         "location": {
-          "sourceId": "server2.conn124.source35",
+          "sourceId": "server2.conn42.child1/29",
           "line": 11,
           "column": 4
         },
         "scope": {
-          "actor": "server2.conn124.environment48",
+          "actor": "server2.conn42.child1/41",
           "type": "function",
           "parent": {
-            "actor": "server2.conn124.environment49",
+            "actor": "server2.conn42.child1/42",
             "type": "function",
             "parent": {
-              "actor": "server2.conn124.environment50",
+              "actor": "server2.conn42.child1/43",
               "type": "block",
               "parent": {
-                "actor": "server2.conn124.environment51",
+                "actor": "server2.conn42.child1/44",
                 "type": "object",
                 "object": {
                   "type": "object",
                   "class": "Window",
-                  "actor": "server2.conn124.pausedobj52",
+                  "actor": "server2.conn42.child1/pausedobj45",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
-                  "ownPropertyLength": 726,
+                  "ownPropertyLength": 775,
                   "preview": {
                     "kind": "ObjectWithURL",
                     "url": "http://localhost:8000/pythagorean/"
@@ -112,7 +112,7 @@
               "frozen": false,
               "name": "math",
               "displayName": "math",
-              "actor": "server2.conn124.pausedobj53",
+              "actor": "server2.conn42.child1/pausedobj46",
               "location": {
                 "url": "http://localhost:8000/pythagorean/pythagorean.js",
                 "line": 3
@@ -183,7 +183,7 @@
             "frozen": false,
             "name": "pythagorean",
             "displayName": "pythagorean",
-            "actor": "server2.conn124.pausedobj54",
+            "actor": "server2.conn42.child1/pausedobj47",
             "location": {
               "url": "http://localhost:8000/pythagorean/pythagorean.js",
               "line": 5
@@ -223,7 +223,7 @@
                 "value": {
                   "type": "object",
                   "class": "Arguments",
-                  "actor": "server2.conn124.pausedobj55",
+                  "actor": "server2.conn42.child1/pausedobj48",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -250,7 +250,7 @@
                   "frozen": false,
                   "name": "exponential",
                   "displayName": "exponential",
-                  "actor": "server2.conn124.pausedobj56",
+                  "actor": "server2.conn42.child1/pausedobj49",
                   "location": {
                     "url": "http://localhost:8000/pythagorean/pythagorean.js",
                     "line": 7
@@ -273,563 +273,41 @@
       "why": {
         "type": "breakpoint",
         "actors": [
-          "server2.conn124.38"
+          "server2.conn42.child1/31"
         ]
       },
       "isInterrupted": false
     },
     "isWaitingOnBreak": false,
-    "frames": [
-      {
-        "id": "server2.conn124.46",
-        "displayName": "pythagorean",
-        "location": {
-          "sourceId": "server2.conn124.source35",
-          "line": 11,
-          "column": 4
-        },
-        "scope": {
-          "actor": "server2.conn124.environment48",
-          "type": "function",
-          "parent": {
-            "actor": "server2.conn124.environment49",
-            "type": "function",
-            "parent": {
-              "actor": "server2.conn124.environment50",
-              "type": "block",
-              "parent": {
-                "actor": "server2.conn124.environment51",
-                "type": "object",
-                "object": {
-                  "type": "object",
-                  "class": "Window",
-                  "actor": "server2.conn124.pausedobj52",
-                  "extensible": true,
-                  "frozen": false,
-                  "sealed": false,
-                  "ownPropertyLength": 726,
-                  "preview": {
-                    "kind": "ObjectWithURL",
-                    "url": "http://localhost:8000/pythagorean/"
-                  }
-                }
-              },
-              "bindings": {
-                "arguments": [],
-                "variables": {}
-              }
-            },
-            "function": {
-              "type": "object",
-              "class": "Function",
-              "actor": "server2.conn124.pausedobj53",
-              "extensible": true,
-              "frozen": false,
-              "sealed": false,
-              "name": "math",
-              "displayName": "math",
-              "parameterNames": [
-                "a",
-                "b"
-              ],
-              "location": {
-                "url": "http://localhost:8000/pythagorean/pythagorean.js",
-                "line": 3
-              }
-            },
-            "bindings": {
-              "arguments": [
-                {
-                  "a": {
-                    "enumerable": true,
-                    "configurable": false,
-                    "value": 2,
-                    "writable": true
-                  }
-                },
-                {
-                  "b": {
-                    "enumerable": true,
-                    "configurable": false,
-                    "value": 3,
-                    "writable": true
-                  }
-                }
-              ],
-              "variables": {
-                "arguments": {
-                  "enumerable": true,
-                  "configurable": false,
-                  "value": {
-                    "type": "object",
-                    "class": "Arguments",
-                    "actor": "server2.conn124.pausedobj57",
-                    "extensible": true,
-                    "frozen": false,
-                    "sealed": false,
-                    "ownPropertyLength": 5,
-                    "preview": {
-                      "kind": "Object",
-                      "ownProperties": {},
-                      "ownPropertiesLength": 5,
-                      "safeGetterValues": {}
-                    }
-                  },
-                  "writable": true
-                },
-                "bar": {
-                  "enumerable": true,
-                  "configurable": false,
-                  "value": 4,
-                  "writable": true
-                },
-                "pythagorean": {
-                  "enumerable": true,
-                  "configurable": false,
-                  "value": {
-                    "type": "object",
-                    "class": "Function",
-                    "actor": "server2.conn124.pausedobj54",
-                    "extensible": true,
-                    "frozen": false,
-                    "sealed": false,
-                    "name": "pythagorean",
-                    "displayName": "pythagorean",
-                    "parameterNames": [
-                      "a",
-                      "b"
-                    ],
-                    "location": {
-                      "url": "http://localhost:8000/pythagorean/pythagorean.js",
-                      "line": 5
-                    }
-                  },
-                  "writable": true
-                }
-              }
-            }
-          },
-          "function": {
-            "type": "object",
-            "class": "Function",
-            "actor": "server2.conn124.pausedobj54",
-            "extensible": true,
-            "frozen": false,
-            "sealed": false,
-            "name": "pythagorean",
-            "displayName": "pythagorean",
-            "parameterNames": [
-              "a",
-              "b"
-            ],
-            "location": {
-              "url": "http://localhost:8000/pythagorean/pythagorean.js",
-              "line": 5
-            }
-          },
-          "bindings": {
-            "arguments": [
-              {
-                "a": {
-                  "enumerable": true,
-                  "configurable": false,
-                  "value": 2,
-                  "writable": true
-                }
-              },
-              {
-                "b": {
-                  "enumerable": true,
-                  "configurable": false,
-                  "value": 3,
-                  "writable": true
-                }
-              }
-            ],
-            "variables": {
-              "arguments": {
-                "enumerable": true,
-                "configurable": false,
-                "value": {
-                  "type": "object",
-                  "class": "Arguments",
-                  "actor": "server2.conn124.pausedobj58",
-                  "extensible": true,
-                  "frozen": false,
-                  "sealed": false,
-                  "ownPropertyLength": 5,
-                  "preview": {
-                    "kind": "Object",
-                    "ownProperties": {},
-                    "ownPropertiesLength": 5,
-                    "safeGetterValues": {}
-                  }
-                },
-                "writable": true
-              },
-              "foo": {
-                "enumerable": true,
-                "configurable": false,
-                "value": 3,
-                "writable": true
-              },
-              "exponential": {
-                "enumerable": true,
-                "configurable": false,
-                "value": {
-                  "type": "object",
-                  "class": "Function",
-                  "actor": "server2.conn124.pausedobj56",
-                  "extensible": true,
-                  "frozen": false,
-                  "sealed": false,
-                  "name": "exponential",
-                  "displayName": "exponential",
-                  "parameterNames": [
-                    "num"
-                  ],
-                  "location": {
-                    "url": "http://localhost:8000/pythagorean/pythagorean.js",
-                    "line": 7
-                  }
-                },
-                "writable": true
-              }
-            }
-          }
-        }
-      },
-      {
-        "id": "server2.conn124.59",
-        "displayName": "math",
-        "location": {
-          "sourceId": "server2.conn124.source35",
-          "line": 14,
-          "column": 2
-        },
-        "scope": {
-          "actor": "server2.conn124.environment49",
-          "type": "function",
-          "parent": {
-            "actor": "server2.conn124.environment50",
-            "type": "block",
-            "parent": {
-              "actor": "server2.conn124.environment51",
-              "type": "object",
-              "object": {
-                "type": "object",
-                "class": "Window",
-                "actor": "server2.conn124.pausedobj52",
-                "extensible": true,
-                "frozen": false,
-                "sealed": false,
-                "ownPropertyLength": 726,
-                "preview": {
-                  "kind": "ObjectWithURL",
-                  "url": "http://localhost:8000/pythagorean/"
-                }
-              }
-            },
-            "bindings": {
-              "arguments": [],
-              "variables": {}
-            }
-          },
-          "function": {
-            "type": "object",
-            "class": "Function",
-            "actor": "server2.conn124.pausedobj53",
-            "extensible": true,
-            "frozen": false,
-            "sealed": false,
-            "name": "math",
-            "displayName": "math",
-            "parameterNames": [
-              "a",
-              "b"
-            ],
-            "location": {
-              "url": "http://localhost:8000/pythagorean/pythagorean.js",
-              "line": 3
-            }
-          },
-          "bindings": {
-            "arguments": [
-              {
-                "a": {
-                  "enumerable": true,
-                  "configurable": false,
-                  "value": 2,
-                  "writable": true
-                }
-              },
-              {
-                "b": {
-                  "enumerable": true,
-                  "configurable": false,
-                  "value": 3,
-                  "writable": true
-                }
-              }
-            ],
-            "variables": {
-              "arguments": {
-                "enumerable": true,
-                "configurable": false,
-                "value": {
-                  "type": "object",
-                  "class": "Arguments",
-                  "actor": "server2.conn124.pausedobj61",
-                  "extensible": true,
-                  "frozen": false,
-                  "sealed": false,
-                  "ownPropertyLength": 5,
-                  "preview": {
-                    "kind": "Object",
-                    "ownProperties": {},
-                    "ownPropertiesLength": 5,
-                    "safeGetterValues": {}
-                  }
-                },
-                "writable": true
-              },
-              "bar": {
-                "enumerable": true,
-                "configurable": false,
-                "value": 4,
-                "writable": true
-              },
-              "pythagorean": {
-                "enumerable": true,
-                "configurable": false,
-                "value": {
-                  "type": "object",
-                  "class": "Function",
-                  "actor": "server2.conn124.pausedobj54",
-                  "extensible": true,
-                  "frozen": false,
-                  "sealed": false,
-                  "name": "pythagorean",
-                  "displayName": "pythagorean",
-                  "parameterNames": [
-                    "a",
-                    "b"
-                  ],
-                  "location": {
-                    "url": "http://localhost:8000/pythagorean/pythagorean.js",
-                    "line": 5
-                  }
-                },
-                "writable": true
-              }
-            }
-          }
-        }
-      },
-      {
-        "id": "server2.conn124.63",
-        "displayName": "onclick",
-        "location": {
-          "sourceId": "server2.conn124.source36",
-          "line": 1,
-          "column": 0
-        },
-        "scope": {
-          "actor": "server2.conn124.environment65",
-          "type": "function",
-          "parent": {
-            "actor": "server2.conn124.environment66",
-            "type": "block",
-            "parent": {
-              "actor": "server2.conn124.environment67",
-              "type": "with",
-              "parent": {
-                "actor": "server2.conn124.environment68",
-                "type": "with",
-                "parent": {
-                  "actor": "server2.conn124.environment50",
-                  "type": "block",
-                  "parent": {
-                    "actor": "server2.conn124.environment51",
-                    "type": "object",
-                    "object": {
-                      "type": "object",
-                      "class": "Window",
-                      "actor": "server2.conn124.pausedobj52",
-                      "extensible": true,
-                      "frozen": false,
-                      "sealed": false,
-                      "ownPropertyLength": 726,
-                      "preview": {
-                        "kind": "ObjectWithURL",
-                        "url": "http://localhost:8000/pythagorean/"
-                      }
-                    }
-                  },
-                  "bindings": {
-                    "arguments": [],
-                    "variables": {}
-                  }
-                },
-                "object": {
-                  "type": "object",
-                  "class": "HTMLDocument",
-                  "actor": "server2.conn124.pausedobj69",
-                  "extensible": true,
-                  "frozen": false,
-                  "sealed": false,
-                  "ownPropertyLength": 1,
-                  "preview": {
-                    "kind": "DOMNode",
-                    "nodeType": 9,
-                    "nodeName": "#document",
-                    "location": "http://localhost:8000/pythagorean/"
-                  }
-                }
-              },
-              "object": {
-                "type": "object",
-                "class": "HTMLButtonElement",
-                "actor": "server2.conn124.pausedobj70",
-                "extensible": true,
-                "frozen": false,
-                "sealed": false,
-                "ownPropertyLength": 0,
-                "preview": {
-                  "kind": "DOMNode",
-                  "nodeType": 1,
-                  "nodeName": "button",
-                  "attributes": {
-                    "onclick": "math(2,3)"
-                  },
-                  "attributesLength": 1
-                }
-              }
-            },
-            "bindings": {
-              "arguments": [],
-              "variables": {}
-            }
-          },
-          "function": {
-            "type": "object",
-            "class": "Function",
-            "actor": "server2.conn124.pausedobj71",
-            "extensible": true,
-            "frozen": false,
-            "sealed": false,
-            "name": "onclick",
-            "displayName": "onclick",
-            "parameterNames": [
-              "event"
-            ],
-            "location": {
-              "url": "http://localhost:8000/pythagorean/",
-              "line": 1
-            }
-          },
-          "bindings": {
-            "arguments": [
-              {
-                "event": {
-                  "enumerable": true,
-                  "configurable": false,
-                  "value": {
-                    "type": "object",
-                    "class": "MouseEvent",
-                    "actor": "server2.conn124.pausedobj72",
-                    "extensible": true,
-                    "frozen": false,
-                    "sealed": false,
-                    "ownPropertyLength": 1,
-                    "preview": {
-                      "kind": "DOMEvent",
-                      "type": "click",
-                      "properties": {
-                        "buttons": 0,
-                        "clientX": 0,
-                        "clientY": 0,
-                        "layerX": 0,
-                        "layerY": 0
-                      },
-                      "target": {
-                        "type": "object",
-                        "class": "HTMLButtonElement",
-                        "actor": "server2.conn124.pausedobj73",
-                        "extensible": true,
-                        "frozen": false,
-                        "sealed": false,
-                        "ownPropertyLength": 0,
-                        "preview": {
-                          "kind": "DOMNode",
-                          "nodeType": 1,
-                          "nodeName": "button",
-                          "attributes": {
-                            "onclick": "math(2,3)"
-                          },
-                          "attributesLength": 1
-                        }
-                      }
-                    }
-                  },
-                  "writable": true
-                }
-              }
-            ],
-            "variables": {
-              "arguments": {
-                "enumerable": true,
-                "configurable": false,
-                "value": {
-                  "type": "object",
-                  "class": "Arguments",
-                  "actor": "server2.conn124.pausedobj74",
-                  "extensible": true,
-                  "frozen": false,
-                  "sealed": false,
-                  "ownPropertyLength": 3,
-                  "preview": {
-                    "kind": "Object",
-                    "ownProperties": {},
-                    "ownPropertiesLength": 3,
-                    "safeGetterValues": {}
-                  }
-                },
-                "writable": true
-              }
-            }
-          }
-        }
-      }
-    ],
+    "frames": null,
     "selectedFrame": {
-      "id": "server2.conn124.46",
+      "id": "server2.conn42.child1/39",
       "displayName": "pythagorean",
       "location": {
-        "sourceId": "server2.conn124.source35",
+        "sourceId": "server2.conn42.child1/29",
         "line": 11,
         "column": 4
       },
       "scope": {
-        "actor": "server2.conn124.environment48",
+        "actor": "server2.conn42.child1/41",
         "type": "function",
         "parent": {
-          "actor": "server2.conn124.environment49",
+          "actor": "server2.conn42.child1/42",
           "type": "function",
           "parent": {
-            "actor": "server2.conn124.environment50",
+            "actor": "server2.conn42.child1/43",
             "type": "block",
             "parent": {
-              "actor": "server2.conn124.environment51",
+              "actor": "server2.conn42.child1/44",
               "type": "object",
               "object": {
                 "type": "object",
                 "class": "Window",
-                "actor": "server2.conn124.pausedobj52",
+                "actor": "server2.conn42.child1/pausedobj45",
                 "extensible": true,
                 "frozen": false,
                 "sealed": false,
-                "ownPropertyLength": 726,
+                "ownPropertyLength": 775,
                 "preview": {
                   "kind": "ObjectWithURL",
                   "url": "http://localhost:8000/pythagorean/"
@@ -844,7 +322,7 @@
           "function": {
             "type": "object",
             "class": "Function",
-            "actor": "server2.conn124.pausedobj53",
+            "actor": "server2.conn42.child1/pausedobj46",
             "extensible": true,
             "frozen": false,
             "sealed": false,
@@ -915,7 +393,7 @@
         "function": {
           "type": "object",
           "class": "Function",
-          "actor": "server2.conn124.pausedobj54",
+          "actor": "server2.conn42.child1/pausedobj47",
           "extensible": true,
           "frozen": false,
           "sealed": false,
@@ -956,7 +434,7 @@
               "value": {
                 "type": "object",
                 "class": "Arguments",
-                "actor": "server2.conn124.pausedobj55",
+                "actor": "server2.conn42.child1/pausedobj48",
                 "extensible": true,
                 "frozen": false,
                 "sealed": false,
@@ -982,7 +460,7 @@
               "value": {
                 "type": "object",
                 "class": "Function",
-                "actor": "server2.conn124.pausedobj56",
+                "actor": "server2.conn42.child1/pausedobj49",
                 "extensible": true,
                 "frozen": false,
                 "sealed": false,

--- a/public/js/test/fixtures/pythagorean.json
+++ b/public/js/test/fixtures/pythagorean.json
@@ -6,20 +6,20 @@
   },
   "sources": {
     "sources": {
-      "server2.conn42.child1/28": {
-        "id": "server2.conn42.child1/28",
+      "server2.conn10.child1/28": {
+        "id": "server2.conn10.child1/28",
         "url": "http://localhost:8000/pythagorean/"
       },
-      "server2.conn42.child1/29": {
-        "id": "server2.conn42.child1/29",
+      "server2.conn10.child1/29": {
+        "id": "server2.conn10.child1/29",
         "url": "http://localhost:8000/pythagorean/pythagorean.js"
       },
-      "server2.conn42.child1/32": {
-        "id": "server2.conn42.child1/32",
+      "server2.conn10.child1/32": {
+        "id": "server2.conn10.child1/32",
         "url": null
       },
-      "server2.conn42.child1/37": {
-        "id": "server2.conn42.child1/37",
+      "server2.conn10.child1/37": {
+        "id": "server2.conn10.child1/37",
         "url": null
       }
     },
@@ -28,33 +28,33 @@
       []
     ],
     "selectedSource": {
-      "id": "server2.conn42.child1/29",
+      "id": "server2.conn10.child1/29",
       "url": "http://localhost:8000/pythagorean/pythagorean.js"
     },
     "sourcesText": {
-      "server2.conn42.child1/29": {
+      "server2.conn10.child1/29": {
         "text": "\"use strict\";\n\nfunction math(a, b) {\n  var bar = 4;\n  function pythagorean(a, b) {\n    var foo = 3;\n    function exponential(num) {\n      foo, bar;\n      return num * num;\n    }\n    return exponential(a) + exponential(b);\n  }\n\n  pythagorean(a,b);\n}\n",
         "contentType": "text/javascript"
       }
     },
     "tabs": [
       {
-        "id": "server2.conn42.child1/29",
+        "id": "server2.conn10.child1/29",
         "url": "http://localhost:8000/pythagorean/pythagorean.js"
       }
     ]
   },
   "breakpoints": {
     "breakpoints": {
-      "server2.conn42.child1/29:11": {
+      "server2.conn10.child1/29:11": {
         "location": {
-          "sourceId": "server2.conn42.child1/29",
+          "sourceId": "server2.conn10.child1/29",
           "line": 11
         },
         "condition": null,
         "disabled": false,
         "loading": false,
-        "id": "server2.conn42.child1/31",
+        "id": "server2.conn10.child1/31",
         "text": "return exponential(a) + exponential(b);"
       }
     }
@@ -66,37 +66,37 @@
   },
   "pause": {
     "pause": {
-      "from": "server2.conn42.child1/26",
+      "from": "server2.conn10.child1/26",
       "type": "paused",
-      "actor": "server2.conn42.child1/pause38",
+      "actor": "server2.conn10.child1/pause38",
       "frame": {
-        "id": "server2.conn42.child1/39",
+        "id": "server2.conn10.child1/39",
         "displayName": "pythagorean",
         "location": {
-          "sourceId": "server2.conn42.child1/29",
+          "sourceId": "server2.conn10.child1/29",
           "line": 11,
           "column": 4
         },
         "scope": {
-          "actor": "server2.conn42.child1/41",
+          "actor": "server2.conn10.child1/41",
           "type": "function",
           "parent": {
-            "actor": "server2.conn42.child1/42",
+            "actor": "server2.conn10.child1/42",
             "type": "function",
             "parent": {
-              "actor": "server2.conn42.child1/43",
+              "actor": "server2.conn10.child1/43",
               "type": "block",
               "parent": {
-                "actor": "server2.conn42.child1/44",
+                "actor": "server2.conn10.child1/44",
                 "type": "object",
                 "object": {
                   "type": "object",
                   "class": "Window",
-                  "actor": "server2.conn42.child1/pausedobj45",
+                  "actor": "server2.conn10.child1/pausedobj45",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
-                  "ownPropertyLength": 775,
+                  "ownPropertyLength": 777,
                   "preview": {
                     "kind": "ObjectWithURL",
                     "url": "http://localhost:8000/pythagorean/"
@@ -112,7 +112,7 @@
               "frozen": false,
               "name": "math",
               "displayName": "math",
-              "actor": "server2.conn42.child1/pausedobj46",
+              "actor": "server2.conn10.child1/pausedobj46",
               "location": {
                 "url": "http://localhost:8000/pythagorean/pythagorean.js",
                 "line": 3
@@ -183,7 +183,7 @@
             "frozen": false,
             "name": "pythagorean",
             "displayName": "pythagorean",
-            "actor": "server2.conn42.child1/pausedobj47",
+            "actor": "server2.conn10.child1/pausedobj47",
             "location": {
               "url": "http://localhost:8000/pythagorean/pythagorean.js",
               "line": 5
@@ -223,7 +223,7 @@
                 "value": {
                   "type": "object",
                   "class": "Arguments",
-                  "actor": "server2.conn42.child1/pausedobj48",
+                  "actor": "server2.conn10.child1/pausedobj48",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -250,7 +250,7 @@
                   "frozen": false,
                   "name": "exponential",
                   "displayName": "exponential",
-                  "actor": "server2.conn42.child1/pausedobj49",
+                  "actor": "server2.conn10.child1/pausedobj49",
                   "location": {
                     "url": "http://localhost:8000/pythagorean/pythagorean.js",
                     "line": 7
@@ -273,41 +273,257 @@
       "why": {
         "type": "breakpoint",
         "actors": [
-          "server2.conn42.child1/31"
+          "server2.conn10.child1/31"
         ]
       },
       "isInterrupted": false
     },
     "isWaitingOnBreak": false,
-    "frames": null,
-    "selectedFrame": {
-      "id": "server2.conn42.child1/39",
-      "displayName": "pythagorean",
-      "location": {
-        "sourceId": "server2.conn42.child1/29",
-        "line": 11,
-        "column": 4
-      },
-      "scope": {
-        "actor": "server2.conn42.child1/41",
-        "type": "function",
-        "parent": {
-          "actor": "server2.conn42.child1/42",
+    "frames": [
+      {
+        "id": "server2.conn10.child1/39",
+        "displayName": "pythagorean",
+        "location": {
+          "sourceId": "server2.conn10.child1/29",
+          "line": 11,
+          "column": 4
+        },
+        "scope": {
+          "actor": "server2.conn10.child1/41",
           "type": "function",
           "parent": {
-            "actor": "server2.conn42.child1/43",
+            "actor": "server2.conn10.child1/42",
+            "type": "function",
+            "parent": {
+              "actor": "server2.conn10.child1/43",
+              "type": "block",
+              "parent": {
+                "actor": "server2.conn10.child1/44",
+                "type": "object",
+                "object": {
+                  "type": "object",
+                  "class": "Window",
+                  "actor": "server2.conn10.child1/pausedobj45",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 777,
+                  "preview": {
+                    "kind": "ObjectWithURL",
+                    "url": "http://localhost:8000/pythagorean/"
+                  }
+                }
+              },
+              "bindings": {
+                "arguments": [],
+                "variables": {}
+              }
+            },
+            "function": {
+              "type": "object",
+              "class": "Function",
+              "actor": "server2.conn10.child1/pausedobj46",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "name": "math",
+              "displayName": "math",
+              "parameterNames": [
+                "a",
+                "b"
+              ],
+              "location": {
+                "url": "http://localhost:8000/pythagorean/pythagorean.js",
+                "line": 3
+              }
+            },
+            "bindings": {
+              "arguments": [
+                {
+                  "a": {
+                    "enumerable": true,
+                    "configurable": false,
+                    "value": 2,
+                    "writable": true
+                  }
+                },
+                {
+                  "b": {
+                    "enumerable": true,
+                    "configurable": false,
+                    "value": 3,
+                    "writable": true
+                  }
+                }
+              ],
+              "variables": {
+                "arguments": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Arguments",
+                    "actor": "server2.conn10.child1/pausedobj50",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "ownPropertyLength": 5,
+                    "preview": {
+                      "kind": "Object",
+                      "ownProperties": {},
+                      "ownPropertiesLength": 5,
+                      "safeGetterValues": {}
+                    }
+                  },
+                  "writable": true
+                },
+                "bar": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": 4,
+                  "writable": true
+                },
+                "pythagorean": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn10.child1/pausedobj47",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "pythagorean",
+                    "displayName": "pythagorean",
+                    "parameterNames": [
+                      "a",
+                      "b"
+                    ],
+                    "location": {
+                      "url": "http://localhost:8000/pythagorean/pythagorean.js",
+                      "line": 5
+                    }
+                  },
+                  "writable": true
+                }
+              }
+            }
+          },
+          "function": {
+            "type": "object",
+            "class": "Function",
+            "actor": "server2.conn10.child1/pausedobj47",
+            "extensible": true,
+            "frozen": false,
+            "sealed": false,
+            "name": "pythagorean",
+            "displayName": "pythagorean",
+            "parameterNames": [
+              "a",
+              "b"
+            ],
+            "location": {
+              "url": "http://localhost:8000/pythagorean/pythagorean.js",
+              "line": 5
+            }
+          },
+          "bindings": {
+            "arguments": [
+              {
+                "a": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": 2,
+                  "writable": true
+                }
+              },
+              {
+                "b": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": 3,
+                  "writable": true
+                }
+              }
+            ],
+            "variables": {
+              "arguments": {
+                "enumerable": true,
+                "configurable": false,
+                "value": {
+                  "type": "object",
+                  "class": "Arguments",
+                  "actor": "server2.conn10.child1/pausedobj51",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 5,
+                  "preview": {
+                    "kind": "Object",
+                    "ownProperties": {},
+                    "ownPropertiesLength": 5,
+                    "safeGetterValues": {}
+                  }
+                },
+                "writable": true
+              },
+              "foo": {
+                "enumerable": true,
+                "configurable": false,
+                "value": 3,
+                "writable": true
+              },
+              "exponential": {
+                "enumerable": true,
+                "configurable": false,
+                "value": {
+                  "type": "object",
+                  "class": "Function",
+                  "actor": "server2.conn10.child1/pausedobj49",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "name": "exponential",
+                  "displayName": "exponential",
+                  "parameterNames": [
+                    "num"
+                  ],
+                  "location": {
+                    "url": "http://localhost:8000/pythagorean/pythagorean.js",
+                    "line": 7
+                  }
+                },
+                "writable": true
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "server2.conn10.child1/52",
+        "displayName": "math",
+        "location": {
+          "sourceId": "server2.conn10.child1/29",
+          "line": 14,
+          "column": 2
+        },
+        "scope": {
+          "actor": "server2.conn10.child1/42",
+          "type": "function",
+          "parent": {
+            "actor": "server2.conn10.child1/43",
             "type": "block",
             "parent": {
-              "actor": "server2.conn42.child1/44",
+              "actor": "server2.conn10.child1/44",
               "type": "object",
               "object": {
                 "type": "object",
                 "class": "Window",
-                "actor": "server2.conn42.child1/pausedobj45",
+                "actor": "server2.conn10.child1/pausedobj45",
                 "extensible": true,
                 "frozen": false,
                 "sealed": false,
-                "ownPropertyLength": 775,
+                "ownPropertyLength": 777,
                 "preview": {
                   "kind": "ObjectWithURL",
                   "url": "http://localhost:8000/pythagorean/"
@@ -322,7 +538,748 @@
           "function": {
             "type": "object",
             "class": "Function",
-            "actor": "server2.conn42.child1/pausedobj46",
+            "actor": "server2.conn10.child1/pausedobj46",
+            "extensible": true,
+            "frozen": false,
+            "sealed": false,
+            "name": "math",
+            "displayName": "math",
+            "parameterNames": [
+              "a",
+              "b"
+            ],
+            "location": {
+              "url": "http://localhost:8000/pythagorean/pythagorean.js",
+              "line": 3
+            }
+          },
+          "bindings": {
+            "arguments": [
+              {
+                "a": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": 2,
+                  "writable": true
+                }
+              },
+              {
+                "b": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": 3,
+                  "writable": true
+                }
+              }
+            ],
+            "variables": {
+              "arguments": {
+                "enumerable": true,
+                "configurable": false,
+                "value": {
+                  "type": "object",
+                  "class": "Arguments",
+                  "actor": "server2.conn10.child1/pausedobj54",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 5,
+                  "preview": {
+                    "kind": "Object",
+                    "ownProperties": {},
+                    "ownPropertiesLength": 5,
+                    "safeGetterValues": {}
+                  }
+                },
+                "writable": true
+              },
+              "bar": {
+                "enumerable": true,
+                "configurable": false,
+                "value": 4,
+                "writable": true
+              },
+              "pythagorean": {
+                "enumerable": true,
+                "configurable": false,
+                "value": {
+                  "type": "object",
+                  "class": "Function",
+                  "actor": "server2.conn10.child1/pausedobj47",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "name": "pythagorean",
+                  "displayName": "pythagorean",
+                  "parameterNames": [
+                    "a",
+                    "b"
+                  ],
+                  "location": {
+                    "url": "http://localhost:8000/pythagorean/pythagorean.js",
+                    "line": 5
+                  }
+                },
+                "writable": true
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "server2.conn10.child1/56",
+        "displayName": "onclick",
+        "location": {
+          "sourceId": "server2.conn10.child1/28",
+          "line": 1,
+          "column": 0
+        },
+        "scope": {
+          "actor": "server2.conn10.child1/58",
+          "type": "function",
+          "parent": {
+            "actor": "server2.conn10.child1/59",
+            "type": "block",
+            "parent": {
+              "actor": "server2.conn10.child1/60",
+              "type": "with",
+              "parent": {
+                "actor": "server2.conn10.child1/61",
+                "type": "with",
+                "parent": {
+                  "actor": "server2.conn10.child1/43",
+                  "type": "block",
+                  "parent": {
+                    "actor": "server2.conn10.child1/44",
+                    "type": "object",
+                    "object": {
+                      "type": "object",
+                      "class": "Window",
+                      "actor": "server2.conn10.child1/pausedobj45",
+                      "extensible": true,
+                      "frozen": false,
+                      "sealed": false,
+                      "ownPropertyLength": 777,
+                      "preview": {
+                        "kind": "ObjectWithURL",
+                        "url": "http://localhost:8000/pythagorean/"
+                      }
+                    }
+                  },
+                  "bindings": {
+                    "arguments": [],
+                    "variables": {}
+                  }
+                },
+                "object": {
+                  "type": "object",
+                  "class": "HTMLDocument",
+                  "actor": "server2.conn10.child1/pausedobj62",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 1,
+                  "preview": {
+                    "kind": "DOMNode",
+                    "nodeType": 9,
+                    "nodeName": "#document",
+                    "location": "http://localhost:8000/pythagorean/"
+                  }
+                }
+              },
+              "object": {
+                "type": "object",
+                "class": "HTMLButtonElement",
+                "actor": "server2.conn10.child1/pausedobj63",
+                "extensible": true,
+                "frozen": false,
+                "sealed": false,
+                "ownPropertyLength": 0,
+                "preview": {
+                  "kind": "DOMNode",
+                  "nodeType": 1,
+                  "nodeName": "button",
+                  "attributes": {
+                    "onclick": "math(2,3)"
+                  },
+                  "attributesLength": 1
+                }
+              }
+            },
+            "bindings": {
+              "arguments": [],
+              "variables": {}
+            }
+          },
+          "function": {
+            "type": "object",
+            "class": "Function",
+            "actor": "server2.conn10.child1/pausedobj64",
+            "extensible": true,
+            "frozen": false,
+            "sealed": false,
+            "name": "onclick",
+            "displayName": "onclick",
+            "parameterNames": [
+              "event"
+            ],
+            "location": {
+              "url": "http://localhost:8000/pythagorean/",
+              "line": 1
+            }
+          },
+          "bindings": {
+            "arguments": [
+              {
+                "event": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "MouseEvent",
+                    "actor": "server2.conn10.child1/pausedobj65",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "ownPropertyLength": 1,
+                    "preview": {
+                      "kind": "DOMEvent",
+                      "type": "click",
+                      "properties": {
+                        "buttons": 0,
+                        "clientX": 0,
+                        "clientY": 0,
+                        "layerX": 0,
+                        "layerY": 0
+                      },
+                      "target": {
+                        "type": "object",
+                        "class": "HTMLButtonElement",
+                        "actor": "server2.conn10.child1/pausedobj66",
+                        "extensible": true,
+                        "frozen": false,
+                        "sealed": false,
+                        "ownPropertyLength": 0,
+                        "preview": {
+                          "kind": "DOMNode",
+                          "nodeType": 1,
+                          "nodeName": "button",
+                          "attributes": {
+                            "onclick": "math(2,3)"
+                          },
+                          "attributesLength": 1
+                        }
+                      }
+                    }
+                  },
+                  "writable": true
+                }
+              }
+            ],
+            "variables": {
+              "arguments": {
+                "enumerable": true,
+                "configurable": false,
+                "value": {
+                  "type": "object",
+                  "class": "Arguments",
+                  "actor": "server2.conn10.child1/pausedobj67",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 3,
+                  "preview": {
+                    "kind": "Object",
+                    "ownProperties": {},
+                    "ownPropertiesLength": 3,
+                    "safeGetterValues": {}
+                  }
+                },
+                "writable": true
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "server2.conn10.child1/69",
+        "displayName": "click",
+        "location": {
+          "sourceId": "server2.conn10.child1/32",
+          "line": 78,
+          "column": 5
+        },
+        "scope": {
+          "actor": "server2.conn10.child1/71",
+          "type": "function",
+          "parent": {
+            "actor": "server2.conn10.child1/72",
+            "type": "function",
+            "parent": {
+              "actor": "server2.conn10.child1/73",
+              "type": "block",
+              "parent": {
+                "actor": "server2.conn10.child1/74",
+                "type": "with",
+                "parent": {
+                  "actor": "server2.conn10.child1/43",
+                  "type": "block",
+                  "parent": {
+                    "actor": "server2.conn10.child1/44",
+                    "type": "object",
+                    "object": {
+                      "type": "object",
+                      "class": "Window",
+                      "actor": "server2.conn10.child1/pausedobj45",
+                      "extensible": true,
+                      "frozen": false,
+                      "sealed": false,
+                      "ownPropertyLength": 777,
+                      "preview": {
+                        "kind": "ObjectWithURL",
+                        "url": "http://localhost:8000/pythagorean/"
+                      }
+                    }
+                  },
+                  "bindings": {
+                    "arguments": [],
+                    "variables": {}
+                  }
+                },
+                "object": {
+                  "type": "object",
+                  "class": "Object",
+                  "actor": "server2.conn10.child1/pausedobj75",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 15,
+                  "preview": {
+                    "kind": "Object",
+                    "ownProperties": {},
+                    "ownPropertiesLength": 15,
+                    "safeGetterValues": {}
+                  }
+                }
+              },
+              "bindings": {
+                "arguments": [],
+                "variables": {
+                  "Debuggee": {
+                    "enumerable": true,
+                    "configurable": false,
+                    "value": {
+                      "type": "object",
+                      "class": "Function",
+                      "actor": "server2.conn10.child1/pausedobj76",
+                      "extensible": true,
+                      "frozen": false,
+                      "sealed": false,
+                      "name": "Debuggee",
+                      "displayName": "Debuggee",
+                      "parameterNames": [],
+                      "location": {
+                        "url": "debugger eval code",
+                        "line": 1
+                      }
+                    },
+                    "writable": true
+                  }
+                }
+              }
+            },
+            "function": {
+              "type": "object",
+              "class": "Function",
+              "actor": "server2.conn10.child1/pausedobj76",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "name": "Debuggee",
+              "displayName": "Debuggee",
+              "parameterNames": [],
+              "location": {
+                "url": "debugger eval code",
+                "line": 1
+              }
+            },
+            "bindings": {
+              "arguments": [],
+              "variables": {
+                "arguments": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "null",
+                    "missingArguments": true
+                  },
+                  "writable": false
+                },
+                "$": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn10.child1/pausedobj77",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "$",
+                    "displayName": "$",
+                    "parameterNames": [
+                      "selector"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 2
+                    }
+                  },
+                  "writable": true
+                },
+                "mouseEvent": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn10.child1/pausedobj78",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "mouseEvent",
+                    "displayName": "mouseEvent",
+                    "parameterNames": [
+                      "eventType"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 12
+                    }
+                  },
+                  "writable": true
+                },
+                "isSpecialCharacter": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn10.child1/pausedobj79",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "isSpecialCharacter",
+                    "displayName": "isSpecialCharacter",
+                    "parameterNames": [
+                      "text"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 25
+                    }
+                  },
+                  "writable": true
+                },
+                "keyInfo": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn10.child1/pausedobj80",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "keyInfo",
+                    "displayName": "keyInfo",
+                    "parameterNames": [
+                      "key",
+                      "eventType"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 29
+                    }
+                  },
+                  "writable": true
+                },
+                "keyEvent": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn10.child1/pausedobj81",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "keyEvent",
+                    "displayName": "keyEvent",
+                    "parameterNames": [
+                      "eventType",
+                      "key"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 45
+                    }
+                  },
+                  "writable": true
+                },
+                "sendKey": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn10.child1/pausedobj82",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "sendKey",
+                    "displayName": "sendKey",
+                    "parameterNames": [
+                      "element",
+                      "key"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 66
+                    }
+                  },
+                  "writable": true
+                },
+                "specialKeysMap": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Object",
+                    "actor": "server2.conn10.child1/pausedobj83",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "ownPropertyLength": 1,
+                    "preview": {
+                      "kind": "Object",
+                      "ownProperties": {
+                        "{enter}": {
+                          "configurable": true,
+                          "enumerable": true,
+                          "writable": true,
+                          "value": 13
+                        }
+                      },
+                      "ownPropertiesLength": 1,
+                      "safeGetterValues": {}
+                    }
+                  },
+                  "writable": true
+                },
+                "click": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "null",
+                    "optimizedOut": true
+                  },
+                  "writable": false
+                },
+                "dblclick": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "null",
+                    "optimizedOut": true
+                  },
+                  "writable": false
+                },
+                "type": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "null",
+                    "optimizedOut": true
+                  },
+                  "writable": false
+                }
+              }
+            }
+          },
+          "function": {
+            "type": "object",
+            "class": "Function",
+            "actor": "server2.conn10.child1/pausedobj84",
+            "extensible": true,
+            "frozen": false,
+            "sealed": false,
+            "name": "click",
+            "displayName": "click",
+            "parameterNames": [
+              "selector"
+            ],
+            "location": {
+              "url": "debugger eval code",
+              "line": 75
+            }
+          },
+          "bindings": {
+            "arguments": [
+              {
+                "selector": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": "button",
+                  "writable": true
+                }
+              }
+            ],
+            "variables": {
+              "arguments": {
+                "enumerable": true,
+                "configurable": false,
+                "value": {
+                  "type": "object",
+                  "class": "Arguments",
+                  "actor": "server2.conn10.child1/pausedobj85",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 3,
+                  "preview": {
+                    "kind": "Object",
+                    "ownProperties": {},
+                    "ownPropertiesLength": 3,
+                    "safeGetterValues": {}
+                  }
+                },
+                "writable": true
+              },
+              "element": {
+                "enumerable": true,
+                "configurable": false,
+                "value": {
+                  "type": "object",
+                  "class": "HTMLButtonElement",
+                  "actor": "server2.conn10.child1/pausedobj86",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 0,
+                  "preview": {
+                    "kind": "DOMNode",
+                    "nodeType": 1,
+                    "nodeName": "button",
+                    "attributes": {
+                      "onclick": "math(2,3)"
+                    },
+                    "attributesLength": 1
+                  }
+                },
+                "writable": true
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "server2.conn10.child1/90",
+        "displayName": "(global)",
+        "location": {
+          "sourceId": "server2.conn10.child1/37",
+          "line": 1,
+          "column": 0
+        },
+        "scope": {
+          "actor": "server2.conn10.child1/91",
+          "type": "with",
+          "parent": {
+            "actor": "server2.conn10.child1/43",
+            "type": "block",
+            "parent": {
+              "actor": "server2.conn10.child1/44",
+              "type": "object",
+              "object": {
+                "type": "object",
+                "class": "Window",
+                "actor": "server2.conn10.child1/pausedobj45",
+                "extensible": true,
+                "frozen": false,
+                "sealed": false,
+                "ownPropertyLength": 777,
+                "preview": {
+                  "kind": "ObjectWithURL",
+                  "url": "http://localhost:8000/pythagorean/"
+                }
+              }
+            },
+            "bindings": {
+              "arguments": [],
+              "variables": {}
+            }
+          },
+          "object": {
+            "type": "object",
+            "class": "Object",
+            "actor": "server2.conn10.child1/pausedobj92",
+            "extensible": true,
+            "frozen": false,
+            "sealed": false,
+            "ownPropertyLength": 15,
+            "preview": {
+              "kind": "Object",
+              "ownProperties": {},
+              "ownPropertiesLength": 15,
+              "safeGetterValues": {}
+            }
+          }
+        }
+      }
+    ],
+    "selectedFrame": {
+      "id": "server2.conn10.child1/39",
+      "displayName": "pythagorean",
+      "location": {
+        "sourceId": "server2.conn10.child1/29",
+        "line": 11,
+        "column": 4
+      },
+      "scope": {
+        "actor": "server2.conn10.child1/41",
+        "type": "function",
+        "parent": {
+          "actor": "server2.conn10.child1/42",
+          "type": "function",
+          "parent": {
+            "actor": "server2.conn10.child1/43",
+            "type": "block",
+            "parent": {
+              "actor": "server2.conn10.child1/44",
+              "type": "object",
+              "object": {
+                "type": "object",
+                "class": "Window",
+                "actor": "server2.conn10.child1/pausedobj45",
+                "extensible": true,
+                "frozen": false,
+                "sealed": false,
+                "ownPropertyLength": 777,
+                "preview": {
+                  "kind": "ObjectWithURL",
+                  "url": "http://localhost:8000/pythagorean/"
+                }
+              }
+            },
+            "bindings": {
+              "arguments": [],
+              "variables": {}
+            }
+          },
+          "function": {
+            "type": "object",
+            "class": "Function",
+            "actor": "server2.conn10.child1/pausedobj46",
             "extensible": true,
             "frozen": false,
             "sealed": false,
@@ -393,7 +1350,7 @@
         "function": {
           "type": "object",
           "class": "Function",
-          "actor": "server2.conn42.child1/pausedobj47",
+          "actor": "server2.conn10.child1/pausedobj47",
           "extensible": true,
           "frozen": false,
           "sealed": false,
@@ -434,7 +1391,7 @@
               "value": {
                 "type": "object",
                 "class": "Arguments",
-                "actor": "server2.conn42.child1/pausedobj48",
+                "actor": "server2.conn10.child1/pausedobj48",
                 "extensible": true,
                 "frozen": false,
                 "sealed": false,
@@ -460,7 +1417,7 @@
               "value": {
                 "type": "object",
                 "class": "Function",
-                "actor": "server2.conn42.child1/pausedobj49",
+                "actor": "server2.conn10.child1/pausedobj49",
                 "extensible": true,
                 "frozen": false,
                 "sealed": false,

--- a/public/js/test/fixtures/todomvc.json
+++ b/public/js/test/fixtures/todomvc.json
@@ -6,60 +6,60 @@
   },
   "sources": {
     "sources": {
-      "server2.conn34.child1/40": {
-        "id": "server2.conn34.child1/40",
+      "server2.conn2.child1/40": {
+        "id": "server2.conn2.child1/40",
         "url": "http://localhost:8000/todomvc/js/routers/router.js"
       },
-      "server2.conn34.child1/30": {
-        "id": "server2.conn34.child1/30",
+      "server2.conn2.child1/30": {
+        "id": "server2.conn2.child1/30",
         "url": "http://localhost:8000/todomvc/bower_components/jquery/jquery.js"
       },
-      "server2.conn34.child1/41": {
-        "id": "server2.conn34.child1/41",
+      "server2.conn2.child1/41": {
+        "id": "server2.conn2.child1/41",
         "url": "http://localhost:8000/todomvc/js/app.js"
       },
-      "server2.conn34.child1/31": {
-        "id": "server2.conn34.child1/31",
+      "server2.conn2.child1/31": {
+        "id": "server2.conn2.child1/31",
         "url": "http://localhost:8000/todomvc/bower_components/underscore/underscore.js"
       },
-      "server2.conn34.child1/32": {
-        "id": "server2.conn34.child1/32",
+      "server2.conn2.child1/32": {
+        "id": "server2.conn2.child1/32",
         "url": "http://localhost:8000/todomvc/bower_components/backbone/backbone.js"
       },
-      "server2.conn34.child1/33": {
-        "id": "server2.conn34.child1/33",
+      "server2.conn2.child1/33": {
+        "id": "server2.conn2.child1/33",
         "url": "http://localhost:8000/todomvc/bower_components/backbone.localStorage/backbone.localStorage.js"
       },
-      "server2.conn34.child1/34": {
-        "id": "server2.conn34.child1/34",
+      "server2.conn2.child1/34": {
+        "id": "server2.conn2.child1/34",
         "url": "http://localhost:8000/todomvc/js/models/todo.js"
       },
-      "server2.conn34.child1/35": {
-        "id": "server2.conn34.child1/35",
+      "server2.conn2.child1/35": {
+        "id": "server2.conn2.child1/35",
         "url": "http://localhost:8000/todomvc/js/collections/todos.js"
       },
-      "server2.conn34.child1/36": {
-        "id": "server2.conn34.child1/36",
+      "server2.conn2.child1/36": {
+        "id": "server2.conn2.child1/36",
         "url": "http://localhost:8000/todomvc/js/views/todo-view.js"
       },
-      "server2.conn34.child1/37": {
-        "id": "server2.conn34.child1/37",
+      "server2.conn2.child1/37": {
+        "id": "server2.conn2.child1/37",
         "url": null
       },
-      "server2.conn34.child1/38": {
-        "id": "server2.conn34.child1/38",
+      "server2.conn2.child1/38": {
+        "id": "server2.conn2.child1/38",
         "url": "http://localhost:8000/todomvc/js/views/app-view.js"
       },
-      "server2.conn34.child1/28": {
-        "id": "server2.conn34.child1/28",
-        "url": "http://localhost:8000/todomvc/"
-      },
-      "server2.conn34.child1/39": {
-        "id": "server2.conn34.child1/39",
+      "server2.conn2.child1/39": {
+        "id": "server2.conn2.child1/39",
         "url": null
       },
-      "server2.conn34.child1/29": {
-        "id": "server2.conn34.child1/29",
+      "server2.conn2.child1/28": {
+        "id": "server2.conn2.child1/28",
+        "url": "http://localhost:8000/todomvc/"
+      },
+      "server2.conn2.child1/29": {
+        "id": "server2.conn2.child1/29",
         "url": "http://localhost:8000/todomvc/bower_components/todomvc-common/base.js"
       }
     },
@@ -68,34 +68,33 @@
       []
     ],
     "selectedSource": {
-      "id": "server2.conn34.child1/34",
+      "id": "server2.conn2.child1/34",
       "url": "http://localhost:8000/todomvc/js/models/todo.js"
     },
     "sourcesText": {
-      "server2.conn34.child1/36": {
+      "server2.conn2.child1/36": {
         "text": "/*global Backbone, jQuery, _, ENTER_KEY, ESC_KEY */\nvar app = app || {};\n\n(function ($) {\n\t'use strict';\n\n\t// Todo Item View\n\t// --------------\n\n\t// The DOM element for a todo item...\n\tapp.TodoView = Backbone.View.extend({\n\t\t//... is a list tag.\n\t\ttagName:  'li',\n\n\t\t// Cache the template function for a single item.\n\t\ttemplate: _.template($('#item-template').html()),\n\n\t\t// The DOM events specific to an item.\n\t\tevents: {\n\t\t\t'click .toggle': 'toggleCompleted',\n\t\t\t'dblclick label': 'edit',\n\t\t\t'click .destroy': 'clear',\n\t\t\t'keypress .edit': 'updateOnEnter',\n\t\t\t'keydown .edit': 'revertOnEscape',\n\t\t\t'blur .edit': 'close'\n\t\t},\n\n\t\t// The TodoView listens for changes to its model, re-rendering. Since\n\t\t// there's a one-to-one correspondence between a **Todo** and a\n\t\t// **TodoView** in this app, we set a direct reference on the model for\n\t\t// convenience.\n\t\tinitialize: function () {\n\t\t\tthis.listenTo(this.model, 'change', this.render);\n\t\t\tthis.listenTo(this.model, 'destroy', this.remove);\n\t\t\tthis.listenTo(this.model, 'visible', this.toggleVisible);\n\t\t},\n\n\t\t// Re-render the titles of the todo item.\n\t\trender: function () {\n\t\t\t// Backbone LocalStorage is adding `id` attribute instantly after\n\t\t\t// creating a model.  This causes our TodoView to render twice. Once\n\t\t\t// after creating a model and once on `id` change.  We want to\n\t\t\t// filter out the second redundant render, which is caused by this\n\t\t\t// `id` change.  It's known Backbone LocalStorage bug, therefore\n\t\t\t// we've to create a workaround.\n\t\t\t// https://github.com/tastejs/todomvc/issues/469\n\t\t\tif (this.model.changed.id !== undefined) {\n\t\t\t\treturn;\n\t\t\t}\n\n\t\t\tthis.$el.html(this.template(this.model.toJSON()));\n\t\t\tthis.$el.toggleClass('completed', this.model.get('completed'));\n\t\t\tthis.toggleVisible();\n\t\t\tthis.$input = this.$('.edit');\n\t\t\treturn this;\n\t\t},\n\n\t\ttoggleVisible: function () {\n\t\t\tthis.$el.toggleClass('hidden', this.isHidden());\n\t\t},\n\n\t\tisHidden: function () {\n\t\t\treturn this.model.get('completed') ?\n\t\t\t\tapp.TodoFilter === 'active' :\n\t\t\t\tapp.TodoFilter === 'completed';\n\t\t},\n\n\t\t// Toggle the `\"completed\"` state of the model.\n\t\ttoggleCompleted: function () {\n\t\t\tthis.model.toggle();\n\t\t},\n\n\t\t// Switch this view into `\"editing\"` mode, displaying the input field.\n\t\tedit: function () {\n\t\t\tthis.$el.addClass('editing');\n\t\t\tthis.$input.focus();\n\t\t},\n\n\t\t// Close the `\"editing\"` mode, saving changes to the todo.\n\t\tclose: function () {\n\t\t\tvar value = this.$input.val();\n\t\t\tvar trimmedValue = value.trim();\n\n\t\t\t// We don't want to handle blur events from an item that is no\n\t\t\t// longer being edited. Relying on the CSS class here has the\n\t\t\t// benefit of us not having to maintain state in the DOM and the\n\t\t\t// JavaScript logic.\n\t\t\tif (!this.$el.hasClass('editing')) {\n\t\t\t\treturn;\n\t\t\t}\n\n\t\t\tif (trimmedValue) {\n\t\t\t\tthis.model.save({ title: trimmedValue });\n\n\t\t\t\tif (value !== trimmedValue) {\n\t\t\t\t\t// Model values changes consisting of whitespaces only are\n\t\t\t\t\t// not causing change to be triggered Therefore we've to\n\t\t\t\t\t// compare untrimmed version with a trimmed one to check\n\t\t\t\t\t// whether anything changed\n\t\t\t\t\t// And if yes, we've to trigger change event ourselves\n\t\t\t\t\tthis.model.trigger('change');\n\t\t\t\t}\n\t\t\t} else {\n\t\t\t\tthis.clear();\n\t\t\t}\n\n\t\t\tthis.$el.removeClass('editing');\n\t\t},\n\n\t\t// If you hit `enter`, we're through editing the item.\n\t\tupdateOnEnter: function (e) {\n\t\t\tif (e.which === ENTER_KEY) {\n\t\t\t\tthis.close();\n\t\t\t}\n\t\t},\n\n\t\t// If you're pressing `escape` we revert your change by simply leaving\n\t\t// the `editing` state.\n\t\trevertOnEscape: function (e) {\n\t\t\tif (e.which === ESC_KEY) {\n\t\t\t\tthis.$el.removeClass('editing');\n\t\t\t\t// Also reset the hidden input back to the original value.\n\t\t\t\tthis.$input.val(this.model.get('title'));\n\t\t\t}\n\t\t},\n\n\t\t// Remove the item, destroy the model from *localStorage* and delete its view.\n\t\tclear: function () {\n\t\t\tthis.model.destroy();\n\t\t}\n\t});\n})(jQuery);\n",
         "contentType": "text/javascript"
       },
-      "server2.conn34.child1/38": {
+      "server2.conn2.child1/38": {
         "text": "/*global Backbone, jQuery, _, ENTER_KEY */\nvar app = app || {};\n\n(function ($) {\n\t'use strict';\n\n\t// The Application\n\t// ---------------\n\n\t// Our overall **AppView** is the top-level piece of UI.\n\tapp.AppView = Backbone.View.extend({\n\n\t\t// Instead of generating a new element, bind to the existing skeleton of\n\t\t// the App already present in the HTML.\n\t\tel: '#todoapp',\n\n\t\t// Our template for the line of statistics at the bottom of the app.\n\t\tstatsTemplate: _.template($('#stats-template').html()),\n\n\t\t// Delegated events for creating new items, and clearing completed ones.\n\t\tevents: {\n\t\t\t'keypress #new-todo': 'createOnEnter',\n\t\t\t'click #clear-completed': 'clearCompleted',\n\t\t\t'click #toggle-all': 'toggleAllComplete'\n\t\t},\n\n\t\t// At initialization we bind to the relevant events on the `Todos`\n\t\t// collection, when items are added or changed. Kick things off by\n\t\t// loading any preexisting todos that might be saved in *localStorage*.\n\t\tinitialize: function () {\n\t\t\tthis.allCheckbox = this.$('#toggle-all')[0];\n\t\t\tthis.$input = this.$('#new-todo');\n\t\t\tthis.$footer = this.$('#footer');\n\t\t\tthis.$main = this.$('#main');\n\t\t\tthis.$list = $('#todo-list');\n\n\t\t\tthis.listenTo(app.todos, 'add', this.addOne);\n\t\t\tthis.listenTo(app.todos, 'reset', this.addAll);\n\t\t\tthis.listenTo(app.todos, 'change:completed', this.filterOne);\n\t\t\tthis.listenTo(app.todos, 'filter', this.filterAll);\n\t\t\tthis.listenTo(app.todos, 'all', this.render);\n\n\t\t\t// Suppresses 'add' events with {reset: true} and prevents the app view\n\t\t\t// from being re-rendered for every model. Only renders when the 'reset'\n\t\t\t// event is triggered at the end of the fetch.\n\t\t\tapp.todos.fetch({reset: true});\n\t\t},\n\n\t\t// Re-rendering the App just means refreshing the statistics -- the rest\n\t\t// of the app doesn't change.\n\t\trender: function () {\n\t\t\tvar completed = app.todos.completed().length;\n\t\t\tvar remaining = app.todos.remaining().length;\n\n\t\t\tif (app.todos.length) {\n\t\t\t\tthis.$main.show();\n\t\t\t\tthis.$footer.show();\n\n\t\t\t\tthis.$footer.html(this.statsTemplate({\n\t\t\t\t\tcompleted: completed,\n\t\t\t\t\tremaining: remaining\n\t\t\t\t}));\n\n\t\t\t\tthis.$('#filters li a')\n\t\t\t\t\t.removeClass('selected')\n\t\t\t\t\t.filter('[href=\"#/' + (app.TodoFilter || '') + '\"]')\n\t\t\t\t\t.addClass('selected');\n\t\t\t} else {\n\t\t\t\tthis.$main.hide();\n\t\t\t\tthis.$footer.hide();\n\t\t\t}\n\n\t\t\tthis.allCheckbox.checked = !remaining;\n\t\t},\n\n\t\t// Add a single todo item to the list by creating a view for it, and\n\t\t// appending its element to the `<ul>`.\n\t\taddOne: function (todo) {\n\t\t\tvar view = new app.TodoView({ model: todo });\n\t\t\tthis.$list.append(view.render().el);\n\t\t},\n\n\t\t// Add all items in the **Todos** collection at once.\n\t\taddAll: function () {\n\t\t\tthis.$list.html('');\n\t\t\tapp.todos.each(this.addOne, this);\n\t\t},\n\n\t\tfilterOne: function (todo) {\n\t\t\ttodo.trigger('visible');\n\t\t},\n\n\t\tfilterAll: function () {\n\t\t\tapp.todos.each(this.filterOne, this);\n\t\t},\n\n\t\t// Generate the attributes for a new Todo item.\n\t\tnewAttributes: function () {\n\t\t\treturn {\n\t\t\t\ttitle: this.$input.val().trim(),\n\t\t\t\torder: app.todos.nextOrder(),\n\t\t\t\tcompleted: false\n\t\t\t};\n\t\t},\n\n\t\t// If you hit return in the main input field, create new **Todo** model,\n\t\t// persisting it to *localStorage*.\n\t\tcreateOnEnter: function (e) {\n\t\t\tif (e.which === ENTER_KEY && this.$input.val().trim()) {\n\t\t\t\tapp.todos.create(this.newAttributes());\n\t\t\t\tthis.$input.val('');\n\t\t\t}\n\t\t},\n\n\t\t// Clear all completed todo items, destroying their models.\n\t\tclearCompleted: function () {\n\t\t\t_.invoke(app.todos.completed(), 'destroy');\n\t\t\treturn false;\n\t\t},\n\n\t\ttoggleAllComplete: function () {\n\t\t\tvar completed = this.allCheckbox.checked;\n\n\t\t\tapp.todos.each(function (todo) {\n\t\t\t\ttodo.save({\n\t\t\t\t\tcompleted: completed\n\t\t\t\t});\n\t\t\t});\n\t\t}\n\t});\n})(jQuery);\n",
         "contentType": "text/javascript"
       },
-      "server2.conn34.child1/34": {
-        "text": "/*global Backbone */\nvar app = app || {};\n\n(function () {\n\t'use strict';\n\n\t// Todo Model\n\t// ----------\n\n\t// Our basic **Todo** model has `title`, `order`, and `completed` attributes.\n\tapp.Todo = Backbone.Model.extend({\n\t\t// Default attributes for the todo\n\t\t// and ensure that each todo created has `title` and `completed` keys.\n\t\tdefaults: {\n\t\t\ttitle: '',\n\t\t\tcompleted: false\n\t\t},\n\n\t\t// Toggle the `completed` state of this todo item.\n\t\ttoggle: function () {\n\t\t\tthis.save({\n\t\t\t\tcompleted: !this.get('completed')\n\t\t\t});\n\t\t}\n\t});\n})();\n",
-        "contentType": "text/javascript"
+      "server2.conn2.child1/34": {
+        "loading": true
       }
     },
     "tabs": [
       {
-        "id": "server2.conn34.child1/36",
+        "id": "server2.conn2.child1/36",
         "url": "http://localhost:8000/todomvc/js/views/todo-view.js"
       },
       {
-        "id": "server2.conn34.child1/38",
+        "id": "server2.conn2.child1/38",
         "url": "http://localhost:8000/todomvc/js/views/app-view.js"
       },
       {
-        "id": "server2.conn34.child1/34",
+        "id": "server2.conn2.child1/34",
         "url": "http://localhost:8000/todomvc/js/models/todo.js"
       }
     ]
@@ -103,7 +102,9 @@
   "breakpoints": {
     "breakpoints": {}
   },
-  "asyncRequests": [],
+  "asyncRequests": [
+    "not-really-uuid3"
+  ],
   "tabs": {
     "tabs": {},
     "selectedTab": null

--- a/public/js/test/fixtures/todomvc.json
+++ b/public/js/test/fixtures/todomvc.json
@@ -6,61 +6,61 @@
   },
   "sources": {
     "sources": {
-      "server2.conn116.source35": {
-        "id": "server2.conn116.source35",
-        "url": "http://localhost:8000/todomvc/bower_components/todomvc-common/base.js"
-      },
-      "server2.conn116.source46": {
-        "id": "server2.conn116.source46",
+      "server2.conn34.child1/40": {
+        "id": "server2.conn34.child1/40",
         "url": "http://localhost:8000/todomvc/js/routers/router.js"
       },
-      "server2.conn116.source36": {
-        "id": "server2.conn116.source36",
+      "server2.conn34.child1/30": {
+        "id": "server2.conn34.child1/30",
         "url": "http://localhost:8000/todomvc/bower_components/jquery/jquery.js"
       },
-      "server2.conn116.source47": {
-        "id": "server2.conn116.source47",
+      "server2.conn34.child1/41": {
+        "id": "server2.conn34.child1/41",
         "url": "http://localhost:8000/todomvc/js/app.js"
       },
-      "server2.conn116.source37": {
-        "id": "server2.conn116.source37",
+      "server2.conn34.child1/31": {
+        "id": "server2.conn34.child1/31",
         "url": "http://localhost:8000/todomvc/bower_components/underscore/underscore.js"
       },
-      "server2.conn116.source48": {
-        "id": "server2.conn116.source48",
-        "url": "http://localhost:8000/todomvc/"
-      },
-      "server2.conn116.source38": {
-        "id": "server2.conn116.source38",
+      "server2.conn34.child1/32": {
+        "id": "server2.conn34.child1/32",
         "url": "http://localhost:8000/todomvc/bower_components/backbone/backbone.js"
       },
-      "server2.conn116.source39": {
-        "id": "server2.conn116.source39",
+      "server2.conn34.child1/33": {
+        "id": "server2.conn34.child1/33",
         "url": "http://localhost:8000/todomvc/bower_components/backbone.localStorage/backbone.localStorage.js"
       },
-      "server2.conn116.source40": {
-        "id": "server2.conn116.source40",
+      "server2.conn34.child1/34": {
+        "id": "server2.conn34.child1/34",
         "url": "http://localhost:8000/todomvc/js/models/todo.js"
       },
-      "server2.conn116.source41": {
-        "id": "server2.conn116.source41",
+      "server2.conn34.child1/35": {
+        "id": "server2.conn34.child1/35",
         "url": "http://localhost:8000/todomvc/js/collections/todos.js"
       },
-      "server2.conn116.source42": {
-        "id": "server2.conn116.source42",
+      "server2.conn34.child1/36": {
+        "id": "server2.conn34.child1/36",
         "url": "http://localhost:8000/todomvc/js/views/todo-view.js"
       },
-      "server2.conn116.source43": {
-        "id": "server2.conn116.source43",
+      "server2.conn34.child1/37": {
+        "id": "server2.conn34.child1/37",
         "url": null
       },
-      "server2.conn116.source44": {
-        "id": "server2.conn116.source44",
+      "server2.conn34.child1/38": {
+        "id": "server2.conn34.child1/38",
         "url": "http://localhost:8000/todomvc/js/views/app-view.js"
       },
-      "server2.conn116.source45": {
-        "id": "server2.conn116.source45",
+      "server2.conn34.child1/28": {
+        "id": "server2.conn34.child1/28",
+        "url": "http://localhost:8000/todomvc/"
+      },
+      "server2.conn34.child1/39": {
+        "id": "server2.conn34.child1/39",
         "url": null
+      },
+      "server2.conn34.child1/29": {
+        "id": "server2.conn34.child1/29",
+        "url": "http://localhost:8000/todomvc/bower_components/todomvc-common/base.js"
       }
     },
     "sourceTree": [
@@ -68,34 +68,34 @@
       []
     ],
     "selectedSource": {
-      "id": "server2.conn116.source40",
+      "id": "server2.conn34.child1/34",
       "url": "http://localhost:8000/todomvc/js/models/todo.js"
     },
     "sourcesText": {
-      "server2.conn116.source42": {
+      "server2.conn34.child1/36": {
         "text": "/*global Backbone, jQuery, _, ENTER_KEY, ESC_KEY */\nvar app = app || {};\n\n(function ($) {\n\t'use strict';\n\n\t// Todo Item View\n\t// --------------\n\n\t// The DOM element for a todo item...\n\tapp.TodoView = Backbone.View.extend({\n\t\t//... is a list tag.\n\t\ttagName:  'li',\n\n\t\t// Cache the template function for a single item.\n\t\ttemplate: _.template($('#item-template').html()),\n\n\t\t// The DOM events specific to an item.\n\t\tevents: {\n\t\t\t'click .toggle': 'toggleCompleted',\n\t\t\t'dblclick label': 'edit',\n\t\t\t'click .destroy': 'clear',\n\t\t\t'keypress .edit': 'updateOnEnter',\n\t\t\t'keydown .edit': 'revertOnEscape',\n\t\t\t'blur .edit': 'close'\n\t\t},\n\n\t\t// The TodoView listens for changes to its model, re-rendering. Since\n\t\t// there's a one-to-one correspondence between a **Todo** and a\n\t\t// **TodoView** in this app, we set a direct reference on the model for\n\t\t// convenience.\n\t\tinitialize: function () {\n\t\t\tthis.listenTo(this.model, 'change', this.render);\n\t\t\tthis.listenTo(this.model, 'destroy', this.remove);\n\t\t\tthis.listenTo(this.model, 'visible', this.toggleVisible);\n\t\t},\n\n\t\t// Re-render the titles of the todo item.\n\t\trender: function () {\n\t\t\t// Backbone LocalStorage is adding `id` attribute instantly after\n\t\t\t// creating a model.  This causes our TodoView to render twice. Once\n\t\t\t// after creating a model and once on `id` change.  We want to\n\t\t\t// filter out the second redundant render, which is caused by this\n\t\t\t// `id` change.  It's known Backbone LocalStorage bug, therefore\n\t\t\t// we've to create a workaround.\n\t\t\t// https://github.com/tastejs/todomvc/issues/469\n\t\t\tif (this.model.changed.id !== undefined) {\n\t\t\t\treturn;\n\t\t\t}\n\n\t\t\tthis.$el.html(this.template(this.model.toJSON()));\n\t\t\tthis.$el.toggleClass('completed', this.model.get('completed'));\n\t\t\tthis.toggleVisible();\n\t\t\tthis.$input = this.$('.edit');\n\t\t\treturn this;\n\t\t},\n\n\t\ttoggleVisible: function () {\n\t\t\tthis.$el.toggleClass('hidden', this.isHidden());\n\t\t},\n\n\t\tisHidden: function () {\n\t\t\treturn this.model.get('completed') ?\n\t\t\t\tapp.TodoFilter === 'active' :\n\t\t\t\tapp.TodoFilter === 'completed';\n\t\t},\n\n\t\t// Toggle the `\"completed\"` state of the model.\n\t\ttoggleCompleted: function () {\n\t\t\tthis.model.toggle();\n\t\t},\n\n\t\t// Switch this view into `\"editing\"` mode, displaying the input field.\n\t\tedit: function () {\n\t\t\tthis.$el.addClass('editing');\n\t\t\tthis.$input.focus();\n\t\t},\n\n\t\t// Close the `\"editing\"` mode, saving changes to the todo.\n\t\tclose: function () {\n\t\t\tvar value = this.$input.val();\n\t\t\tvar trimmedValue = value.trim();\n\n\t\t\t// We don't want to handle blur events from an item that is no\n\t\t\t// longer being edited. Relying on the CSS class here has the\n\t\t\t// benefit of us not having to maintain state in the DOM and the\n\t\t\t// JavaScript logic.\n\t\t\tif (!this.$el.hasClass('editing')) {\n\t\t\t\treturn;\n\t\t\t}\n\n\t\t\tif (trimmedValue) {\n\t\t\t\tthis.model.save({ title: trimmedValue });\n\n\t\t\t\tif (value !== trimmedValue) {\n\t\t\t\t\t// Model values changes consisting of whitespaces only are\n\t\t\t\t\t// not causing change to be triggered Therefore we've to\n\t\t\t\t\t// compare untrimmed version with a trimmed one to check\n\t\t\t\t\t// whether anything changed\n\t\t\t\t\t// And if yes, we've to trigger change event ourselves\n\t\t\t\t\tthis.model.trigger('change');\n\t\t\t\t}\n\t\t\t} else {\n\t\t\t\tthis.clear();\n\t\t\t}\n\n\t\t\tthis.$el.removeClass('editing');\n\t\t},\n\n\t\t// If you hit `enter`, we're through editing the item.\n\t\tupdateOnEnter: function (e) {\n\t\t\tif (e.which === ENTER_KEY) {\n\t\t\t\tthis.close();\n\t\t\t}\n\t\t},\n\n\t\t// If you're pressing `escape` we revert your change by simply leaving\n\t\t// the `editing` state.\n\t\trevertOnEscape: function (e) {\n\t\t\tif (e.which === ESC_KEY) {\n\t\t\t\tthis.$el.removeClass('editing');\n\t\t\t\t// Also reset the hidden input back to the original value.\n\t\t\t\tthis.$input.val(this.model.get('title'));\n\t\t\t}\n\t\t},\n\n\t\t// Remove the item, destroy the model from *localStorage* and delete its view.\n\t\tclear: function () {\n\t\t\tthis.model.destroy();\n\t\t}\n\t});\n})(jQuery);\n",
         "contentType": "text/javascript"
       },
-      "server2.conn116.source44": {
+      "server2.conn34.child1/38": {
         "text": "/*global Backbone, jQuery, _, ENTER_KEY */\nvar app = app || {};\n\n(function ($) {\n\t'use strict';\n\n\t// The Application\n\t// ---------------\n\n\t// Our overall **AppView** is the top-level piece of UI.\n\tapp.AppView = Backbone.View.extend({\n\n\t\t// Instead of generating a new element, bind to the existing skeleton of\n\t\t// the App already present in the HTML.\n\t\tel: '#todoapp',\n\n\t\t// Our template for the line of statistics at the bottom of the app.\n\t\tstatsTemplate: _.template($('#stats-template').html()),\n\n\t\t// Delegated events for creating new items, and clearing completed ones.\n\t\tevents: {\n\t\t\t'keypress #new-todo': 'createOnEnter',\n\t\t\t'click #clear-completed': 'clearCompleted',\n\t\t\t'click #toggle-all': 'toggleAllComplete'\n\t\t},\n\n\t\t// At initialization we bind to the relevant events on the `Todos`\n\t\t// collection, when items are added or changed. Kick things off by\n\t\t// loading any preexisting todos that might be saved in *localStorage*.\n\t\tinitialize: function () {\n\t\t\tthis.allCheckbox = this.$('#toggle-all')[0];\n\t\t\tthis.$input = this.$('#new-todo');\n\t\t\tthis.$footer = this.$('#footer');\n\t\t\tthis.$main = this.$('#main');\n\t\t\tthis.$list = $('#todo-list');\n\n\t\t\tthis.listenTo(app.todos, 'add', this.addOne);\n\t\t\tthis.listenTo(app.todos, 'reset', this.addAll);\n\t\t\tthis.listenTo(app.todos, 'change:completed', this.filterOne);\n\t\t\tthis.listenTo(app.todos, 'filter', this.filterAll);\n\t\t\tthis.listenTo(app.todos, 'all', this.render);\n\n\t\t\t// Suppresses 'add' events with {reset: true} and prevents the app view\n\t\t\t// from being re-rendered for every model. Only renders when the 'reset'\n\t\t\t// event is triggered at the end of the fetch.\n\t\t\tapp.todos.fetch({reset: true});\n\t\t},\n\n\t\t// Re-rendering the App just means refreshing the statistics -- the rest\n\t\t// of the app doesn't change.\n\t\trender: function () {\n\t\t\tvar completed = app.todos.completed().length;\n\t\t\tvar remaining = app.todos.remaining().length;\n\n\t\t\tif (app.todos.length) {\n\t\t\t\tthis.$main.show();\n\t\t\t\tthis.$footer.show();\n\n\t\t\t\tthis.$footer.html(this.statsTemplate({\n\t\t\t\t\tcompleted: completed,\n\t\t\t\t\tremaining: remaining\n\t\t\t\t}));\n\n\t\t\t\tthis.$('#filters li a')\n\t\t\t\t\t.removeClass('selected')\n\t\t\t\t\t.filter('[href=\"#/' + (app.TodoFilter || '') + '\"]')\n\t\t\t\t\t.addClass('selected');\n\t\t\t} else {\n\t\t\t\tthis.$main.hide();\n\t\t\t\tthis.$footer.hide();\n\t\t\t}\n\n\t\t\tthis.allCheckbox.checked = !remaining;\n\t\t},\n\n\t\t// Add a single todo item to the list by creating a view for it, and\n\t\t// appending its element to the `<ul>`.\n\t\taddOne: function (todo) {\n\t\t\tvar view = new app.TodoView({ model: todo });\n\t\t\tthis.$list.append(view.render().el);\n\t\t},\n\n\t\t// Add all items in the **Todos** collection at once.\n\t\taddAll: function () {\n\t\t\tthis.$list.html('');\n\t\t\tapp.todos.each(this.addOne, this);\n\t\t},\n\n\t\tfilterOne: function (todo) {\n\t\t\ttodo.trigger('visible');\n\t\t},\n\n\t\tfilterAll: function () {\n\t\t\tapp.todos.each(this.filterOne, this);\n\t\t},\n\n\t\t// Generate the attributes for a new Todo item.\n\t\tnewAttributes: function () {\n\t\t\treturn {\n\t\t\t\ttitle: this.$input.val().trim(),\n\t\t\t\torder: app.todos.nextOrder(),\n\t\t\t\tcompleted: false\n\t\t\t};\n\t\t},\n\n\t\t// If you hit return in the main input field, create new **Todo** model,\n\t\t// persisting it to *localStorage*.\n\t\tcreateOnEnter: function (e) {\n\t\t\tif (e.which === ENTER_KEY && this.$input.val().trim()) {\n\t\t\t\tapp.todos.create(this.newAttributes());\n\t\t\t\tthis.$input.val('');\n\t\t\t}\n\t\t},\n\n\t\t// Clear all completed todo items, destroying their models.\n\t\tclearCompleted: function () {\n\t\t\t_.invoke(app.todos.completed(), 'destroy');\n\t\t\treturn false;\n\t\t},\n\n\t\ttoggleAllComplete: function () {\n\t\t\tvar completed = this.allCheckbox.checked;\n\n\t\t\tapp.todos.each(function (todo) {\n\t\t\t\ttodo.save({\n\t\t\t\t\tcompleted: completed\n\t\t\t\t});\n\t\t\t});\n\t\t}\n\t});\n})(jQuery);\n",
         "contentType": "text/javascript"
       },
-      "server2.conn116.source40": {
+      "server2.conn34.child1/34": {
         "text": "/*global Backbone */\nvar app = app || {};\n\n(function () {\n\t'use strict';\n\n\t// Todo Model\n\t// ----------\n\n\t// Our basic **Todo** model has `title`, `order`, and `completed` attributes.\n\tapp.Todo = Backbone.Model.extend({\n\t\t// Default attributes for the todo\n\t\t// and ensure that each todo created has `title` and `completed` keys.\n\t\tdefaults: {\n\t\t\ttitle: '',\n\t\t\tcompleted: false\n\t\t},\n\n\t\t// Toggle the `completed` state of this todo item.\n\t\ttoggle: function () {\n\t\t\tthis.save({\n\t\t\t\tcompleted: !this.get('completed')\n\t\t\t});\n\t\t}\n\t});\n})();\n",
         "contentType": "text/javascript"
       }
     },
     "tabs": [
       {
-        "id": "server2.conn116.source42",
+        "id": "server2.conn34.child1/36",
         "url": "http://localhost:8000/todomvc/js/views/todo-view.js"
       },
       {
-        "id": "server2.conn116.source44",
+        "id": "server2.conn34.child1/38",
         "url": "http://localhost:8000/todomvc/js/views/app-view.js"
       },
       {
-        "id": "server2.conn116.source40",
+        "id": "server2.conn34.child1/34",
         "url": "http://localhost:8000/todomvc/js/models/todo.js"
       }
     ]

--- a/public/js/test/fixtures/todomvc.updateOnEnter.json
+++ b/public/js/test/fixtures/todomvc.updateOnEnter.json
@@ -6,77 +6,73 @@
   },
   "sources": {
     "sources": {
-      "server2.conn38.child1/59": {
-        "id": "server2.conn38.child1/59",
-        "url": null
-      },
-      "server2.conn38.child1/37": {
-        "id": "server2.conn38.child1/37",
-        "url": null
-      },
-      "server2.conn38.child1/48": {
-        "id": "server2.conn38.child1/48",
-        "url": null
-      },
-      "server2.conn38.child1/38": {
-        "id": "server2.conn38.child1/38",
-        "url": "http://localhost:8000/todomvc/js/views/app-view.js"
-      },
-      "server2.conn38.child1/28": {
-        "id": "server2.conn38.child1/28",
-        "url": "http://localhost:8000/todomvc/"
-      },
-      "server2.conn38.child1/39": {
-        "id": "server2.conn38.child1/39",
-        "url": null
-      },
-      "server2.conn38.child1/29": {
-        "id": "server2.conn38.child1/29",
-        "url": "http://localhost:8000/todomvc/bower_components/todomvc-common/base.js"
-      },
-      "server2.conn38.child1/40": {
-        "id": "server2.conn38.child1/40",
+      "server2.conn6.child1/40": {
+        "id": "server2.conn6.child1/40",
         "url": "http://localhost:8000/todomvc/js/routers/router.js"
       },
-      "server2.conn38.child1/30": {
-        "id": "server2.conn38.child1/30",
+      "server2.conn6.child1/30": {
+        "id": "server2.conn6.child1/30",
         "url": "http://localhost:8000/todomvc/bower_components/jquery/jquery.js"
       },
-      "server2.conn38.child1/41": {
-        "id": "server2.conn38.child1/41",
+      "server2.conn6.child1/41": {
+        "id": "server2.conn6.child1/41",
         "url": "http://localhost:8000/todomvc/js/app.js"
       },
-      "server2.conn38.child1/31": {
-        "id": "server2.conn38.child1/31",
+      "server2.conn6.child1/31": {
+        "id": "server2.conn6.child1/31",
         "url": "http://localhost:8000/todomvc/bower_components/underscore/underscore.js"
       },
-      "server2.conn38.child1/53": {
-        "id": "server2.conn38.child1/53",
+      "server2.conn6.child1/53": {
+        "id": "server2.conn6.child1/53",
         "url": null
       },
-      "server2.conn38.child1/32": {
-        "id": "server2.conn38.child1/32",
+      "server2.conn6.child1/32": {
+        "id": "server2.conn6.child1/32",
         "url": "http://localhost:8000/todomvc/bower_components/backbone/backbone.js"
       },
-      "server2.conn38.child1/54": {
-        "id": "server2.conn38.child1/54",
+      "server2.conn6.child1/54": {
+        "id": "server2.conn6.child1/54",
         "url": null
       },
-      "server2.conn38.child1/33": {
-        "id": "server2.conn38.child1/33",
+      "server2.conn6.child1/33": {
+        "id": "server2.conn6.child1/33",
         "url": "http://localhost:8000/todomvc/bower_components/backbone.localStorage/backbone.localStorage.js"
       },
-      "server2.conn38.child1/34": {
-        "id": "server2.conn38.child1/34",
+      "server2.conn6.child1/34": {
+        "id": "server2.conn6.child1/34",
         "url": "http://localhost:8000/todomvc/js/models/todo.js"
       },
-      "server2.conn38.child1/35": {
-        "id": "server2.conn38.child1/35",
+      "server2.conn6.child1/35": {
+        "id": "server2.conn6.child1/35",
         "url": "http://localhost:8000/todomvc/js/collections/todos.js"
       },
-      "server2.conn38.child1/36": {
-        "id": "server2.conn38.child1/36",
+      "server2.conn6.child1/36": {
+        "id": "server2.conn6.child1/36",
         "url": "http://localhost:8000/todomvc/js/views/todo-view.js"
+      },
+      "server2.conn6.child1/37": {
+        "id": "server2.conn6.child1/37",
+        "url": null
+      },
+      "server2.conn6.child1/48": {
+        "id": "server2.conn6.child1/48",
+        "url": null
+      },
+      "server2.conn6.child1/38": {
+        "id": "server2.conn6.child1/38",
+        "url": "http://localhost:8000/todomvc/js/views/app-view.js"
+      },
+      "server2.conn6.child1/28": {
+        "id": "server2.conn6.child1/28",
+        "url": "http://localhost:8000/todomvc/"
+      },
+      "server2.conn6.child1/39": {
+        "id": "server2.conn6.child1/39",
+        "url": null
+      },
+      "server2.conn6.child1/29": {
+        "id": "server2.conn6.child1/29",
+        "url": "http://localhost:8000/todomvc/bower_components/todomvc-common/base.js"
       }
     },
     "sourceTree": [
@@ -84,55 +80,55 @@
       []
     ],
     "selectedSource": {
-      "id": "server2.conn38.child1/36",
+      "id": "server2.conn6.child1/36",
       "url": "http://localhost:8000/todomvc/js/views/todo-view.js"
     },
     "sourcesText": {
-      "server2.conn38.child1/36": {
+      "server2.conn6.child1/36": {
         "text": "/*global Backbone, jQuery, _, ENTER_KEY, ESC_KEY */\nvar app = app || {};\n\n(function ($) {\n\t'use strict';\n\n\t// Todo Item View\n\t// --------------\n\n\t// The DOM element for a todo item...\n\tapp.TodoView = Backbone.View.extend({\n\t\t//... is a list tag.\n\t\ttagName:  'li',\n\n\t\t// Cache the template function for a single item.\n\t\ttemplate: _.template($('#item-template').html()),\n\n\t\t// The DOM events specific to an item.\n\t\tevents: {\n\t\t\t'click .toggle': 'toggleCompleted',\n\t\t\t'dblclick label': 'edit',\n\t\t\t'click .destroy': 'clear',\n\t\t\t'keypress .edit': 'updateOnEnter',\n\t\t\t'keydown .edit': 'revertOnEscape',\n\t\t\t'blur .edit': 'close'\n\t\t},\n\n\t\t// The TodoView listens for changes to its model, re-rendering. Since\n\t\t// there's a one-to-one correspondence between a **Todo** and a\n\t\t// **TodoView** in this app, we set a direct reference on the model for\n\t\t// convenience.\n\t\tinitialize: function () {\n\t\t\tthis.listenTo(this.model, 'change', this.render);\n\t\t\tthis.listenTo(this.model, 'destroy', this.remove);\n\t\t\tthis.listenTo(this.model, 'visible', this.toggleVisible);\n\t\t},\n\n\t\t// Re-render the titles of the todo item.\n\t\trender: function () {\n\t\t\t// Backbone LocalStorage is adding `id` attribute instantly after\n\t\t\t// creating a model.  This causes our TodoView to render twice. Once\n\t\t\t// after creating a model and once on `id` change.  We want to\n\t\t\t// filter out the second redundant render, which is caused by this\n\t\t\t// `id` change.  It's known Backbone LocalStorage bug, therefore\n\t\t\t// we've to create a workaround.\n\t\t\t// https://github.com/tastejs/todomvc/issues/469\n\t\t\tif (this.model.changed.id !== undefined) {\n\t\t\t\treturn;\n\t\t\t}\n\n\t\t\tthis.$el.html(this.template(this.model.toJSON()));\n\t\t\tthis.$el.toggleClass('completed', this.model.get('completed'));\n\t\t\tthis.toggleVisible();\n\t\t\tthis.$input = this.$('.edit');\n\t\t\treturn this;\n\t\t},\n\n\t\ttoggleVisible: function () {\n\t\t\tthis.$el.toggleClass('hidden', this.isHidden());\n\t\t},\n\n\t\tisHidden: function () {\n\t\t\treturn this.model.get('completed') ?\n\t\t\t\tapp.TodoFilter === 'active' :\n\t\t\t\tapp.TodoFilter === 'completed';\n\t\t},\n\n\t\t// Toggle the `\"completed\"` state of the model.\n\t\ttoggleCompleted: function () {\n\t\t\tthis.model.toggle();\n\t\t},\n\n\t\t// Switch this view into `\"editing\"` mode, displaying the input field.\n\t\tedit: function () {\n\t\t\tthis.$el.addClass('editing');\n\t\t\tthis.$input.focus();\n\t\t},\n\n\t\t// Close the `\"editing\"` mode, saving changes to the todo.\n\t\tclose: function () {\n\t\t\tvar value = this.$input.val();\n\t\t\tvar trimmedValue = value.trim();\n\n\t\t\t// We don't want to handle blur events from an item that is no\n\t\t\t// longer being edited. Relying on the CSS class here has the\n\t\t\t// benefit of us not having to maintain state in the DOM and the\n\t\t\t// JavaScript logic.\n\t\t\tif (!this.$el.hasClass('editing')) {\n\t\t\t\treturn;\n\t\t\t}\n\n\t\t\tif (trimmedValue) {\n\t\t\t\tthis.model.save({ title: trimmedValue });\n\n\t\t\t\tif (value !== trimmedValue) {\n\t\t\t\t\t// Model values changes consisting of whitespaces only are\n\t\t\t\t\t// not causing change to be triggered Therefore we've to\n\t\t\t\t\t// compare untrimmed version with a trimmed one to check\n\t\t\t\t\t// whether anything changed\n\t\t\t\t\t// And if yes, we've to trigger change event ourselves\n\t\t\t\t\tthis.model.trigger('change');\n\t\t\t\t}\n\t\t\t} else {\n\t\t\t\tthis.clear();\n\t\t\t}\n\n\t\t\tthis.$el.removeClass('editing');\n\t\t},\n\n\t\t// If you hit `enter`, we're through editing the item.\n\t\tupdateOnEnter: function (e) {\n\t\t\tif (e.which === ENTER_KEY) {\n\t\t\t\tthis.close();\n\t\t\t}\n\t\t},\n\n\t\t// If you're pressing `escape` we revert your change by simply leaving\n\t\t// the `editing` state.\n\t\trevertOnEscape: function (e) {\n\t\t\tif (e.which === ESC_KEY) {\n\t\t\t\tthis.$el.removeClass('editing');\n\t\t\t\t// Also reset the hidden input back to the original value.\n\t\t\t\tthis.$input.val(this.model.get('title'));\n\t\t\t}\n\t\t},\n\n\t\t// Remove the item, destroy the model from *localStorage* and delete its view.\n\t\tclear: function () {\n\t\t\tthis.model.destroy();\n\t\t}\n\t});\n})(jQuery);\n",
         "contentType": "text/javascript"
       }
     },
     "tabs": [
       {
-        "id": "server2.conn38.child1/36",
+        "id": "server2.conn6.child1/36",
         "url": "http://localhost:8000/todomvc/js/views/todo-view.js"
       }
     ]
   },
   "breakpoints": {
     "breakpoints": {
-      "server2.conn38.child1/36:113": {
+      "server2.conn6.child1/36:113": {
         "location": {
-          "sourceId": "server2.conn38.child1/36",
+          "sourceId": "server2.conn6.child1/36",
           "line": 113
         },
         "condition": null,
         "disabled": false,
         "loading": false,
-        "id": "server2.conn38.child1/43",
+        "id": "server2.conn6.child1/43",
         "text": "this.close();"
       },
-      "server2.conn38.child1/36:119": {
+      "server2.conn6.child1/36:119": {
         "location": {
-          "sourceId": "server2.conn38.child1/36",
+          "sourceId": "server2.conn6.child1/36",
           "line": 119
         },
         "condition": null,
         "disabled": false,
         "loading": false,
-        "id": "server2.conn38.child1/45",
+        "id": "server2.conn6.child1/45",
         "text": "revertOnEscape: function (e) {"
       },
-      "server2.conn38.child1/36:121": {
+      "server2.conn6.child1/36:121": {
         "location": {
-          "sourceId": "server2.conn38.child1/36",
+          "sourceId": "server2.conn6.child1/36",
           "line": 121
         },
         "condition": null,
         "disabled": true,
         "loading": false,
-        "id": "server2.conn38.child1/47",
+        "id": "server2.conn6.child1/47",
         "text": "this.$el.removeClass('editing');"
       }
     }
@@ -144,37 +140,37 @@
   },
   "pause": {
     "pause": {
-      "from": "server2.conn38.child1/26",
+      "from": "server2.conn6.child1/26",
       "type": "paused",
-      "actor": "server2.conn38.child1/pause60",
+      "actor": "server2.conn6.child1/pause55",
       "frame": {
-        "id": "server2.conn38.child1/61",
+        "id": "server2.conn6.child1/56",
         "displayName": "app.TodoView<.updateOnEnter",
         "location": {
-          "sourceId": "server2.conn38.child1/36",
+          "sourceId": "server2.conn6.child1/36",
           "line": 113,
           "column": 4
         },
         "scope": {
-          "actor": "server2.conn38.child1/63",
+          "actor": "server2.conn6.child1/58",
           "type": "function",
           "parent": {
-            "actor": "server2.conn38.child1/64",
+            "actor": "server2.conn6.child1/59",
             "type": "function",
             "parent": {
-              "actor": "server2.conn38.child1/65",
+              "actor": "server2.conn6.child1/60",
               "type": "block",
               "parent": {
-                "actor": "server2.conn38.child1/66",
+                "actor": "server2.conn6.child1/61",
                 "type": "object",
                 "object": {
                   "type": "object",
                   "class": "Window",
-                  "actor": "server2.conn38.child1/pausedobj67",
+                  "actor": "server2.conn6.child1/pausedobj62",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
-                  "ownPropertyLength": 783,
+                  "ownPropertyLength": 785,
                   "preview": {
                     "kind": "ObjectWithURL",
                     "url": "http://localhost:8000/todomvc/"
@@ -189,7 +185,7 @@
             "function": {
               "type": "object",
               "class": "Function",
-              "actor": "server2.conn38.child1/pausedobj68",
+              "actor": "server2.conn6.child1/pausedobj63",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -231,7 +227,7 @@
           "function": {
             "frozen": false,
             "displayName": "app.TodoView<.updateOnEnter",
-            "actor": "server2.conn38.child1/pausedobj69",
+            "actor": "server2.conn6.child1/pausedobj64",
             "location": {
               "url": "http://localhost:8000/todomvc/js/views/todo-view.js",
               "line": 111
@@ -253,7 +249,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj70",
+                    "actor": "server2.conn6.child1/pausedobj65",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -269,7 +265,7 @@
                             "frozen": false,
                             "name": "returnFalse",
                             "displayName": "returnFalse",
-                            "actor": "server2.conn38.child1/pausedobj72",
+                            "actor": "server2.conn6.child1/pausedobj67",
                             "location": {
                               "url": "http://localhost:8000/todomvc/bower_components/jquery/jquery.js",
                               "line": 4309
@@ -294,7 +290,7 @@
                           "value": {
                             "type": "object",
                             "class": "Event",
-                            "actor": "server2.conn38.child1/pausedobj71",
+                            "actor": "server2.conn6.child1/pausedobj66",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -308,7 +304,7 @@
                                 "bubbles": true,
                                 "isTrusted": false,
                                 "cancelable": false,
-                                "timeStamp": 1467818195619794,
+                                "timeStamp": 1467821730772228,
                                 "defaultPrevented": false,
                                 "NONE": 0,
                                 "AT_TARGET": 2,
@@ -317,23 +313,23 @@
                             }
                           }
                         },
-                        "jQuery2030924186586612804": {
-                          "configurable": true,
-                          "enumerable": true,
-                          "writable": true,
-                          "value": true
-                        },
                         "keyCode": {
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
                           "value": 13
                         },
+                        "jQuery20305902781820274127": {
+                          "configurable": true,
+                          "enumerable": true,
+                          "writable": true,
+                          "value": true
+                        },
                         "timeStamp": {
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": 1467818195619794
+                          "value": 1467821730772228
                         },
                         "char": {
                           "configurable": true,
@@ -378,7 +374,7 @@
                 "value": {
                   "type": "object",
                   "class": "Arguments",
-                  "actor": "server2.conn38.child1/pausedobj73",
+                  "actor": "server2.conn6.child1/pausedobj68",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -400,7 +396,7 @@
       "why": {
         "type": "breakpoint",
         "actors": [
-          "server2.conn38.child1/43"
+          "server2.conn6.child1/43"
         ]
       },
       "isInterrupted": false
@@ -408,33 +404,33 @@
     "isWaitingOnBreak": false,
     "frames": [
       {
-        "id": "server2.conn38.child1/61",
+        "id": "server2.conn6.child1/56",
         "displayName": "app.TodoView<.updateOnEnter",
         "location": {
-          "sourceId": "server2.conn38.child1/36",
+          "sourceId": "server2.conn6.child1/36",
           "line": 113,
           "column": 4
         },
         "scope": {
-          "actor": "server2.conn38.child1/63",
+          "actor": "server2.conn6.child1/58",
           "type": "function",
           "parent": {
-            "actor": "server2.conn38.child1/64",
+            "actor": "server2.conn6.child1/59",
             "type": "function",
             "parent": {
-              "actor": "server2.conn38.child1/65",
+              "actor": "server2.conn6.child1/60",
               "type": "block",
               "parent": {
-                "actor": "server2.conn38.child1/66",
+                "actor": "server2.conn6.child1/61",
                 "type": "object",
                 "object": {
                   "type": "object",
                   "class": "Window",
-                  "actor": "server2.conn38.child1/pausedobj67",
+                  "actor": "server2.conn6.child1/pausedobj62",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
-                  "ownPropertyLength": 783,
+                  "ownPropertyLength": 785,
                   "preview": {
                     "kind": "ObjectWithURL",
                     "url": "http://localhost:8000/todomvc/"
@@ -449,7 +445,7 @@
             "function": {
               "type": "object",
               "class": "Function",
-              "actor": "server2.conn38.child1/pausedobj68",
+              "actor": "server2.conn6.child1/pausedobj63",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -491,7 +487,7 @@
           "function": {
             "type": "object",
             "class": "Function",
-            "actor": "server2.conn38.child1/pausedobj69",
+            "actor": "server2.conn6.child1/pausedobj64",
             "extensible": true,
             "frozen": false,
             "sealed": false,
@@ -513,7 +509,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj70",
+                    "actor": "server2.conn6.child1/pausedobj65",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -528,7 +524,7 @@
                           "value": {
                             "type": "object",
                             "class": "Event",
-                            "actor": "server2.conn38.child1/pausedobj71",
+                            "actor": "server2.conn6.child1/pausedobj66",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -542,7 +538,7 @@
                                 "bubbles": true,
                                 "cancelable": false,
                                 "defaultPrevented": false,
-                                "timeStamp": 1467818195619794,
+                                "timeStamp": 1467821730772228,
                                 "NONE": 0,
                                 "CAPTURING_PHASE": 1,
                                 "AT_TARGET": 2,
@@ -564,7 +560,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn38.child1/pausedobj72",
+                            "actor": "server2.conn6.child1/pausedobj67",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -581,9 +577,9 @@
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": 1467818195619794
+                          "value": 1467821730772228
                         },
-                        "jQuery2030924186586612804": {
+                        "jQuery20305902781820274127": {
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
@@ -638,7 +634,7 @@
                 "value": {
                   "type": "object",
                   "class": "Arguments",
-                  "actor": "server2.conn38.child1/pausedobj81",
+                  "actor": "server2.conn6.child1/pausedobj76",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -657,33 +653,33 @@
         }
       },
       {
-        "id": "server2.conn38.child1/82",
+        "id": "server2.conn6.child1/77",
         "displayName": "jQuery.event.dispatch",
         "location": {
-          "sourceId": "server2.conn38.child1/30",
+          "sourceId": "server2.conn6.child1/30",
           "line": 4675,
           "column": 14
         },
         "scope": {
-          "actor": "server2.conn38.child1/84",
+          "actor": "server2.conn6.child1/79",
           "type": "function",
           "parent": {
-            "actor": "server2.conn38.child1/85",
+            "actor": "server2.conn6.child1/80",
             "type": "function",
             "parent": {
-              "actor": "server2.conn38.child1/65",
+              "actor": "server2.conn6.child1/60",
               "type": "block",
               "parent": {
-                "actor": "server2.conn38.child1/66",
+                "actor": "server2.conn6.child1/61",
                 "type": "object",
                 "object": {
                   "type": "object",
                   "class": "Window",
-                  "actor": "server2.conn38.child1/pausedobj67",
+                  "actor": "server2.conn6.child1/pausedobj62",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
-                  "ownPropertyLength": 783,
+                  "ownPropertyLength": 785,
                   "preview": {
                     "kind": "ObjectWithURL",
                     "url": "http://localhost:8000/todomvc/"
@@ -698,7 +694,7 @@
             "function": {
               "type": "object",
               "class": "Function",
-              "actor": "server2.conn38.child1/pausedobj86",
+              "actor": "server2.conn6.child1/pausedobj81",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -720,11 +716,11 @@
                     "value": {
                       "type": "object",
                       "class": "Window",
-                      "actor": "server2.conn38.child1/pausedobj87",
+                      "actor": "server2.conn6.child1/pausedobj82",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
-                      "ownPropertyLength": 783,
+                      "ownPropertyLength": 785,
                       "preview": {
                         "kind": "ObjectWithURL",
                         "url": "http://localhost:8000/todomvc/"
@@ -760,7 +756,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj88",
+                    "actor": "server2.conn6.child1/pausedobj83",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -775,7 +771,7 @@
                           "value": {
                             "type": "object",
                             "class": "HTMLDocument",
-                            "actor": "server2.conn38.child1/pausedobj89",
+                            "actor": "server2.conn6.child1/pausedobj84",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -807,7 +803,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj90",
+                    "actor": "server2.conn6.child1/pausedobj85",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -822,7 +818,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn38.child1/pausedobj91",
+                            "actor": "server2.conn6.child1/pausedobj86",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -841,7 +837,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn38.child1/pausedobj92",
+                            "actor": "server2.conn6.child1/pausedobj87",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -863,7 +859,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn38.child1/pausedobj93",
+                            "actor": "server2.conn6.child1/pausedobj88",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -882,7 +878,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn38.child1/pausedobj94",
+                            "actor": "server2.conn6.child1/pausedobj89",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -904,7 +900,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn38.child1/pausedobj95",
+                            "actor": "server2.conn6.child1/pausedobj90",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -923,7 +919,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn38.child1/pausedobj96",
+                            "actor": "server2.conn6.child1/pausedobj91",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -945,7 +941,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn38.child1/pausedobj97",
+                            "actor": "server2.conn6.child1/pausedobj92",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -964,7 +960,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn38.child1/pausedobj98",
+                            "actor": "server2.conn6.child1/pausedobj93",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -983,7 +979,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn38.child1/pausedobj99",
+                            "actor": "server2.conn6.child1/pausedobj94",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -1002,7 +998,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn38.child1/pausedobj100",
+                            "actor": "server2.conn6.child1/pausedobj95",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -1034,7 +1030,7 @@
                   "value": {
                     "type": "object",
                     "class": "HTMLDocument",
-                    "actor": "server2.conn38.child1/pausedobj101",
+                    "actor": "server2.conn6.child1/pausedobj96",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1054,7 +1050,7 @@
                   "value": {
                     "type": "object",
                     "class": "HTMLHtmlElement",
-                    "actor": "server2.conn38.child1/pausedobj102",
+                    "actor": "server2.conn6.child1/pausedobj97",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1094,7 +1090,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj103",
+                    "actor": "server2.conn6.child1/pausedobj98",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1169,7 +1165,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj104",
+                    "actor": "server2.conn6.child1/pausedobj99",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1187,7 +1183,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj105",
+                    "actor": "server2.conn6.child1/pausedobj100",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1205,7 +1201,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj106",
+                    "actor": "server2.conn6.child1/pausedobj101",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1224,7 +1220,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj107",
+                    "actor": "server2.conn6.child1/pausedobj102",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1242,7 +1238,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj108",
+                    "actor": "server2.conn6.child1/pausedobj103",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1258,7 +1254,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj109",
+                    "actor": "server2.conn6.child1/pausedobj104",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1276,7 +1272,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj110",
+                    "actor": "server2.conn6.child1/pausedobj105",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1292,7 +1288,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj111",
+                    "actor": "server2.conn6.child1/pausedobj106",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1314,7 +1310,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj112",
+                    "actor": "server2.conn6.child1/pausedobj107",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1329,7 +1325,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj113",
+                    "actor": "server2.conn6.child1/pausedobj108",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1344,7 +1340,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj114",
+                    "actor": "server2.conn6.child1/pausedobj109",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1359,7 +1355,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj115",
+                    "actor": "server2.conn6.child1/pausedobj110",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1374,7 +1370,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj116",
+                    "actor": "server2.conn6.child1/pausedobj111",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1389,7 +1385,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj117",
+                    "actor": "server2.conn6.child1/pausedobj112",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1411,7 +1407,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj118",
+                    "actor": "server2.conn6.child1/pausedobj113",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1430,7 +1426,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj119",
+                    "actor": "server2.conn6.child1/pausedobj114",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1452,7 +1448,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj120",
+                    "actor": "server2.conn6.child1/pausedobj115",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1467,7 +1463,7 @@
                           "value": {
                             "type": "object",
                             "class": "Object",
-                            "actor": "server2.conn38.child1/pausedobj121",
+                            "actor": "server2.conn6.child1/pausedobj116",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -1481,7 +1477,7 @@
                           "value": {
                             "type": "object",
                             "class": "Object",
-                            "actor": "server2.conn38.child1/pausedobj122",
+                            "actor": "server2.conn6.child1/pausedobj117",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -1501,7 +1497,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj123",
+                    "actor": "server2.conn6.child1/pausedobj118",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1523,7 +1519,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj124",
+                    "actor": "server2.conn6.child1/pausedobj119",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1538,7 +1534,7 @@
                           "value": {
                             "type": "object",
                             "class": "Object",
-                            "actor": "server2.conn38.child1/pausedobj125",
+                            "actor": "server2.conn6.child1/pausedobj120",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -1553,7 +1549,7 @@
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": "jQuery20309241865866128040.43034317485030704"
+                          "value": "jQuery203059027818202741270.24574955802811005"
                         }
                       },
                       "ownPropertiesLength": 2,
@@ -1568,7 +1564,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj126",
+                    "actor": "server2.conn6.child1/pausedobj121",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1583,14 +1579,14 @@
                           "value": {
                             "type": "object",
                             "class": "Object",
-                            "actor": "server2.conn38.child1/pausedobj127",
+                            "actor": "server2.conn6.child1/pausedobj122",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
-                            "ownPropertyLength": 14,
+                            "ownPropertyLength": 17,
                             "preview": {
                               "kind": "ArrayLike",
-                              "length": 14
+                              "length": 17
                             }
                           }
                         },
@@ -1598,7 +1594,7 @@
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": "jQuery20309241865866128040.5040131599394156"
+                          "value": "jQuery203059027818202741270.8790218811926621"
                         }
                       },
                       "ownPropertiesLength": 2,
@@ -1613,7 +1609,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj128",
+                    "actor": "server2.conn6.child1/pausedobj123",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1628,7 +1624,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj129",
+                    "actor": "server2.conn6.child1/pausedobj124",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1643,7 +1639,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj130",
+                    "actor": "server2.conn6.child1/pausedobj125",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1663,7 +1659,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj131",
+                    "actor": "server2.conn6.child1/pausedobj126",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1695,7 +1691,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj132",
+                    "actor": "server2.conn6.child1/pausedobj127",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1710,7 +1706,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn38.child1/pausedobj133",
+                            "actor": "server2.conn6.child1/pausedobj128",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -1739,7 +1735,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj134",
+                    "actor": "server2.conn6.child1/pausedobj129",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1754,7 +1750,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj135",
+                    "actor": "server2.conn6.child1/pausedobj130",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1769,7 +1765,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj136",
+                    "actor": "server2.conn6.child1/pausedobj131",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1784,7 +1780,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj137",
+                    "actor": "server2.conn6.child1/pausedobj132",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1799,7 +1795,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj138",
+                    "actor": "server2.conn6.child1/pausedobj133",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1814,7 +1810,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj139",
+                    "actor": "server2.conn6.child1/pausedobj134",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1829,7 +1825,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj140",
+                    "actor": "server2.conn6.child1/pausedobj135",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1844,7 +1840,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj141",
+                    "actor": "server2.conn6.child1/pausedobj136",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1864,7 +1860,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj142",
+                    "actor": "server2.conn6.child1/pausedobj137",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1884,7 +1880,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj143",
+                    "actor": "server2.conn6.child1/pausedobj138",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1904,7 +1900,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj144",
+                    "actor": "server2.conn6.child1/pausedobj139",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1919,7 +1915,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj145",
+                    "actor": "server2.conn6.child1/pausedobj140",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1934,7 +1930,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj146",
+                    "actor": "server2.conn6.child1/pausedobj141",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1949,7 +1945,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj147",
+                    "actor": "server2.conn6.child1/pausedobj142",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1994,7 +1990,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj148",
+                    "actor": "server2.conn6.child1/pausedobj143",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2017,7 +2013,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj149",
+                    "actor": "server2.conn6.child1/pausedobj144",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2041,7 +2037,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj150",
+                    "actor": "server2.conn6.child1/pausedobj145",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2056,7 +2052,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj151",
+                    "actor": "server2.conn6.child1/pausedobj146",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2071,7 +2067,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj152",
+                    "actor": "server2.conn6.child1/pausedobj147",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2086,7 +2082,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj153",
+                    "actor": "server2.conn6.child1/pausedobj148",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2101,7 +2097,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj154",
+                    "actor": "server2.conn6.child1/pausedobj149",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2116,7 +2112,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj155",
+                    "actor": "server2.conn6.child1/pausedobj150",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2131,7 +2127,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj156",
+                    "actor": "server2.conn6.child1/pausedobj151",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2146,7 +2142,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj157",
+                    "actor": "server2.conn6.child1/pausedobj152",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2161,7 +2157,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj158",
+                    "actor": "server2.conn6.child1/pausedobj153",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2176,7 +2172,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj159",
+                    "actor": "server2.conn6.child1/pausedobj154",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2191,7 +2187,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj160",
+                            "actor": "server2.conn6.child1/pausedobj155",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2209,7 +2205,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj161",
+                            "actor": "server2.conn6.child1/pausedobj156",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2227,7 +2223,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj162",
+                            "actor": "server2.conn6.child1/pausedobj157",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2245,7 +2241,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj163",
+                            "actor": "server2.conn6.child1/pausedobj158",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2263,7 +2259,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj164",
+                            "actor": "server2.conn6.child1/pausedobj159",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2281,7 +2277,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj165",
+                            "actor": "server2.conn6.child1/pausedobj160",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2299,7 +2295,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj160",
+                            "actor": "server2.conn6.child1/pausedobj155",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2317,7 +2313,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj161",
+                            "actor": "server2.conn6.child1/pausedobj156",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2335,7 +2331,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj161",
+                            "actor": "server2.conn6.child1/pausedobj156",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2353,7 +2349,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj161",
+                            "actor": "server2.conn6.child1/pausedobj156",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2376,7 +2372,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj166",
+                    "actor": "server2.conn6.child1/pausedobj161",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2399,7 +2395,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj167",
+                    "actor": "server2.conn6.child1/pausedobj162",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2421,7 +2417,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj168",
+                    "actor": "server2.conn6.child1/pausedobj163",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2443,7 +2439,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj169",
+                    "actor": "server2.conn6.child1/pausedobj164",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2466,7 +2462,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj170",
+                    "actor": "server2.conn6.child1/pausedobj165",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2489,7 +2485,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj171",
+                    "actor": "server2.conn6.child1/pausedobj166",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2512,7 +2508,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj172",
+                    "actor": "server2.conn6.child1/pausedobj167",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2535,7 +2531,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj173",
+                    "actor": "server2.conn6.child1/pausedobj168",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2566,7 +2562,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj174",
+                    "actor": "server2.conn6.child1/pausedobj169",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2581,7 +2577,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj175",
+                    "actor": "server2.conn6.child1/pausedobj170",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2596,7 +2592,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj176",
+                    "actor": "server2.conn6.child1/pausedobj171",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2611,7 +2607,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj177",
+                    "actor": "server2.conn6.child1/pausedobj172",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2626,7 +2622,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj178",
+                    "actor": "server2.conn6.child1/pausedobj173",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2641,7 +2637,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj179",
+                    "actor": "server2.conn6.child1/pausedobj174",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2668,7 +2664,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj180",
+                    "actor": "server2.conn6.child1/pausedobj175",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2707,7 +2703,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj181",
+                    "actor": "server2.conn6.child1/pausedobj176",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2740,7 +2736,7 @@
                   "value": {
                     "type": "object",
                     "class": "Array",
-                    "actor": "server2.conn38.child1/pausedobj182",
+                    "actor": "server2.conn6.child1/pausedobj177",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2764,7 +2760,7 @@
                   "value": {
                     "type": "object",
                     "class": "Array",
-                    "actor": "server2.conn38.child1/pausedobj183",
+                    "actor": "server2.conn6.child1/pausedobj178",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2788,7 +2784,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj184",
+                    "actor": "server2.conn6.child1/pausedobj179",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2811,7 +2807,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj185",
+                    "actor": "server2.conn6.child1/pausedobj180",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2834,7 +2830,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj186",
+                    "actor": "server2.conn6.child1/pausedobj181",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2856,7 +2852,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj187",
+                    "actor": "server2.conn6.child1/pausedobj182",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2879,7 +2875,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj188",
+                    "actor": "server2.conn6.child1/pausedobj183",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2903,7 +2899,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj189",
+                    "actor": "server2.conn6.child1/pausedobj184",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2929,7 +2925,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj190",
+                    "actor": "server2.conn6.child1/pausedobj185",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2953,7 +2949,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj191",
+                    "actor": "server2.conn6.child1/pausedobj186",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2975,7 +2971,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj192",
+                    "actor": "server2.conn6.child1/pausedobj187",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2998,7 +2994,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj193",
+                    "actor": "server2.conn6.child1/pausedobj188",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3013,7 +3009,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj194",
+                    "actor": "server2.conn6.child1/pausedobj189",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3028,7 +3024,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj195",
+                    "actor": "server2.conn6.child1/pausedobj190",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3043,7 +3039,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj196",
+                    "actor": "server2.conn6.child1/pausedobj191",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3058,7 +3054,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj197",
+                    "actor": "server2.conn6.child1/pausedobj192",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3073,7 +3069,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj198",
+                    "actor": "server2.conn6.child1/pausedobj193",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3098,7 +3094,7 @@
                   "value": {
                     "type": "object",
                     "class": "Array",
-                    "actor": "server2.conn38.child1/pausedobj199",
+                    "actor": "server2.conn6.child1/pausedobj194",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3125,7 +3121,7 @@
                 "ajax_nonce": {
                   "enumerable": true,
                   "configurable": false,
-                  "value": 1467818191372,
+                  "value": 1467821724735,
                   "writable": true
                 },
                 "ajax_rquery": {
@@ -3134,7 +3130,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj200",
+                    "actor": "server2.conn6.child1/pausedobj195",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3149,7 +3145,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj201",
+                    "actor": "server2.conn6.child1/pausedobj196",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3164,7 +3160,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj202",
+                    "actor": "server2.conn6.child1/pausedobj197",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3179,7 +3175,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj203",
+                    "actor": "server2.conn6.child1/pausedobj198",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3194,7 +3190,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj204",
+                    "actor": "server2.conn6.child1/pausedobj199",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3209,7 +3205,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj205",
+                    "actor": "server2.conn6.child1/pausedobj200",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3224,7 +3220,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj206",
+                    "actor": "server2.conn6.child1/pausedobj201",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3239,7 +3235,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj207",
+                    "actor": "server2.conn6.child1/pausedobj202",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3261,7 +3257,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj208",
+                    "actor": "server2.conn6.child1/pausedobj203",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3276,7 +3272,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj209",
+                            "actor": "server2.conn6.child1/pausedobj204",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -3294,7 +3290,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj210",
+                            "actor": "server2.conn6.child1/pausedobj205",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -3312,7 +3308,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj211",
+                            "actor": "server2.conn6.child1/pausedobj206",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -3336,7 +3332,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj212",
+                    "actor": "server2.conn6.child1/pausedobj207",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3351,7 +3347,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj213",
+                            "actor": "server2.conn6.child1/pausedobj208",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -3369,7 +3365,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj214",
+                            "actor": "server2.conn6.child1/pausedobj209",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -3399,7 +3395,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj215",
+                    "actor": "server2.conn6.child1/pausedobj210",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3424,7 +3420,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj216",
+                    "actor": "server2.conn6.child1/pausedobj211",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3447,7 +3443,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj217",
+                    "actor": "server2.conn6.child1/pausedobj212",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3471,7 +3467,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj218",
+                    "actor": "server2.conn6.child1/pausedobj213",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3496,7 +3492,7 @@
                   "value": {
                     "type": "object",
                     "class": "Array",
-                    "actor": "server2.conn38.child1/pausedobj219",
+                    "actor": "server2.conn6.child1/pausedobj214",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3515,7 +3511,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj220",
+                    "actor": "server2.conn6.child1/pausedobj215",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3536,7 +3532,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj221",
+                    "actor": "server2.conn6.child1/pausedobj216",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3575,7 +3571,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj222",
+                    "actor": "server2.conn6.child1/pausedobj217",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3611,7 +3607,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj223",
+                    "actor": "server2.conn6.child1/pausedobj218",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3626,7 +3622,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj224",
+                    "actor": "server2.conn6.child1/pausedobj219",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3641,7 +3637,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn38.child1/pausedobj225",
+                    "actor": "server2.conn6.child1/pausedobj220",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3656,7 +3652,7 @@
                   "value": {
                     "type": "object",
                     "class": "Array",
-                    "actor": "server2.conn38.child1/pausedobj226",
+                    "actor": "server2.conn6.child1/pausedobj221",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3668,7 +3664,7 @@
                         {
                           "type": "object",
                           "class": "Function",
-                          "actor": "server2.conn38.child1/pausedobj227",
+                          "actor": "server2.conn6.child1/pausedobj222",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -3695,7 +3691,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj228",
+                    "actor": "server2.conn6.child1/pausedobj223",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3710,7 +3706,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn38.child1/pausedobj229",
+                            "actor": "server2.conn6.child1/pausedobj224",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -3734,7 +3730,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj230",
+                    "actor": "server2.conn6.child1/pausedobj225",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3754,7 +3750,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj231",
+                    "actor": "server2.conn6.child1/pausedobj226",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3778,7 +3774,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj232",
+                    "actor": "server2.conn6.child1/pausedobj227",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3802,7 +3798,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj233",
+                    "actor": "server2.conn6.child1/pausedobj228",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3825,7 +3821,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj234",
+                    "actor": "server2.conn6.child1/pausedobj229",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3851,7 +3847,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj235",
+                    "actor": "server2.conn6.child1/pausedobj230",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3874,7 +3870,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj236",
+                    "actor": "server2.conn6.child1/pausedobj231",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3959,7 +3955,7 @@
           "function": {
             "type": "object",
             "class": "Function",
-            "actor": "server2.conn38.child1/pausedobj237",
+            "actor": "server2.conn6.child1/pausedobj232",
             "extensible": true,
             "frozen": false,
             "sealed": false,
@@ -3981,7 +3977,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj238",
+                    "actor": "server2.conn6.child1/pausedobj233",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3996,7 +3992,7 @@
                           "value": {
                             "type": "object",
                             "class": "Event",
-                            "actor": "server2.conn38.child1/pausedobj71",
+                            "actor": "server2.conn6.child1/pausedobj66",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -4010,7 +4006,7 @@
                                 "bubbles": true,
                                 "cancelable": false,
                                 "defaultPrevented": false,
-                                "timeStamp": 1467818195619794,
+                                "timeStamp": 1467821730772228,
                                 "NONE": 0,
                                 "CAPTURING_PHASE": 1,
                                 "AT_TARGET": 2,
@@ -4032,7 +4028,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn38.child1/pausedobj72",
+                            "actor": "server2.conn6.child1/pausedobj67",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -4049,9 +4045,9 @@
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": 1467818195619794
+                          "value": 1467821730772228
                         },
-                        "jQuery2030924186586612804": {
+                        "jQuery20305902781820274127": {
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
@@ -4126,7 +4122,7 @@
                 "value": {
                   "type": "object",
                   "class": "Object",
-                  "actor": "server2.conn38.child1/pausedobj239",
+                  "actor": "server2.conn6.child1/pausedobj234",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -4141,7 +4137,7 @@
                         "value": {
                           "type": "object",
                           "class": "HTMLInputElement",
-                          "actor": "server2.conn38.child1/pausedobj240",
+                          "actor": "server2.conn6.child1/pausedobj235",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -4152,7 +4148,7 @@
                             "nodeName": "input",
                             "attributes": {
                               "class": "edit",
-                              "value": "hitherethere"
+                              "value": "hitheretheretheretherethere"
                             },
                             "attributesLength": 2
                           }
@@ -4165,7 +4161,7 @@
                         "value": {
                           "type": "object",
                           "class": "Array",
-                          "actor": "server2.conn38.child1/pausedobj241",
+                          "actor": "server2.conn6.child1/pausedobj236",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -4189,7 +4185,7 @@
                 "value": {
                   "type": "object",
                   "class": "Object",
-                  "actor": "server2.conn38.child1/pausedobj242",
+                  "actor": "server2.conn6.child1/pausedobj237",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -4224,7 +4220,7 @@
                         "value": {
                           "type": "object",
                           "class": "Function",
-                          "actor": "server2.conn38.child1/pausedobj243",
+                          "actor": "server2.conn6.child1/pausedobj238",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -4255,7 +4251,7 @@
                         "configurable": true,
                         "enumerable": true,
                         "writable": true,
-                        "value": "delegateEventsview10"
+                        "value": "delegateEventsview13"
                       }
                     },
                     "ownPropertiesLength": 8,
@@ -4270,7 +4266,7 @@
                 "value": {
                   "type": "object",
                   "class": "Array",
-                  "actor": "server2.conn38.child1/pausedobj244",
+                  "actor": "server2.conn6.child1/pausedobj239",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -4282,7 +4278,7 @@
                       {
                         "type": "object",
                         "class": "Object",
-                        "actor": "server2.conn38.child1/pausedobj245",
+                        "actor": "server2.conn6.child1/pausedobj240",
                         "extensible": true,
                         "frozen": false,
                         "sealed": false,
@@ -4299,7 +4295,7 @@
                 "value": {
                   "type": "object",
                   "class": "Array",
-                  "actor": "server2.conn38.child1/pausedobj246",
+                  "actor": "server2.conn6.child1/pausedobj241",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -4311,7 +4307,7 @@
                       {
                         "type": "object",
                         "class": "Object",
-                        "actor": "server2.conn38.child1/pausedobj80",
+                        "actor": "server2.conn6.child1/pausedobj75",
                         "extensible": true,
                         "frozen": false,
                         "sealed": false,
@@ -4328,7 +4324,7 @@
                 "value": {
                   "type": "object",
                   "class": "Array",
-                  "actor": "server2.conn38.child1/pausedobj247",
+                  "actor": "server2.conn6.child1/pausedobj242",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -4340,7 +4336,7 @@
                       {
                         "type": "object",
                         "class": "Object",
-                        "actor": "server2.conn38.child1/pausedobj248",
+                        "actor": "server2.conn6.child1/pausedobj243",
                         "extensible": true,
                         "frozen": false,
                         "sealed": false,
@@ -4357,7 +4353,7 @@
                 "value": {
                   "type": "object",
                   "class": "Object",
-                  "actor": "server2.conn38.child1/pausedobj249",
+                  "actor": "server2.conn6.child1/pausedobj244",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -4377,7 +4373,7 @@
                 "value": {
                   "type": "object",
                   "class": "Arguments",
-                  "actor": "server2.conn38.child1/pausedobj250",
+                  "actor": "server2.conn6.child1/pausedobj245",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -4396,36 +4392,36 @@
         }
       },
       {
-        "id": "server2.conn38.child1/251",
+        "id": "server2.conn6.child1/246",
         "displayName": "jQuery.event.add/elemData.handle",
         "location": {
-          "sourceId": "server2.conn38.child1/30",
+          "sourceId": "server2.conn6.child1/30",
           "line": 4360,
           "column": 5
         },
         "scope": {
-          "actor": "server2.conn38.child1/253",
+          "actor": "server2.conn6.child1/248",
           "type": "function",
           "parent": {
-            "actor": "server2.conn38.child1/254",
+            "actor": "server2.conn6.child1/249",
             "type": "function",
             "parent": {
-              "actor": "server2.conn38.child1/85",
+              "actor": "server2.conn6.child1/80",
               "type": "function",
               "parent": {
-                "actor": "server2.conn38.child1/65",
+                "actor": "server2.conn6.child1/60",
                 "type": "block",
                 "parent": {
-                  "actor": "server2.conn38.child1/66",
+                  "actor": "server2.conn6.child1/61",
                   "type": "object",
                   "object": {
                     "type": "object",
                     "class": "Window",
-                    "actor": "server2.conn38.child1/pausedobj67",
+                    "actor": "server2.conn6.child1/pausedobj62",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
-                    "ownPropertyLength": 783,
+                    "ownPropertyLength": 785,
                     "preview": {
                       "kind": "ObjectWithURL",
                       "url": "http://localhost:8000/todomvc/"
@@ -4440,7 +4436,7 @@
               "function": {
                 "type": "object",
                 "class": "Function",
-                "actor": "server2.conn38.child1/pausedobj86",
+                "actor": "server2.conn6.child1/pausedobj81",
                 "extensible": true,
                 "frozen": false,
                 "sealed": false,
@@ -4462,11 +4458,11 @@
                       "value": {
                         "type": "object",
                         "class": "Window",
-                        "actor": "server2.conn38.child1/pausedobj87",
+                        "actor": "server2.conn6.child1/pausedobj82",
                         "extensible": true,
                         "frozen": false,
                         "sealed": false,
-                        "ownPropertyLength": 783,
+                        "ownPropertyLength": 785,
                         "preview": {
                           "kind": "ObjectWithURL",
                           "url": "http://localhost:8000/todomvc/"
@@ -4502,7 +4498,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj88",
+                      "actor": "server2.conn6.child1/pausedobj83",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4517,7 +4513,7 @@
                             "value": {
                               "type": "object",
                               "class": "HTMLDocument",
-                              "actor": "server2.conn38.child1/pausedobj89",
+                              "actor": "server2.conn6.child1/pausedobj84",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4549,7 +4545,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj90",
+                      "actor": "server2.conn6.child1/pausedobj85",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4564,7 +4560,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn38.child1/pausedobj91",
+                              "actor": "server2.conn6.child1/pausedobj86",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4583,7 +4579,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn38.child1/pausedobj92",
+                              "actor": "server2.conn6.child1/pausedobj87",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4605,7 +4601,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn38.child1/pausedobj93",
+                              "actor": "server2.conn6.child1/pausedobj88",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4624,7 +4620,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn38.child1/pausedobj94",
+                              "actor": "server2.conn6.child1/pausedobj89",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4646,7 +4642,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn38.child1/pausedobj95",
+                              "actor": "server2.conn6.child1/pausedobj90",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4665,7 +4661,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn38.child1/pausedobj96",
+                              "actor": "server2.conn6.child1/pausedobj91",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4687,7 +4683,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn38.child1/pausedobj97",
+                              "actor": "server2.conn6.child1/pausedobj92",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4706,7 +4702,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn38.child1/pausedobj98",
+                              "actor": "server2.conn6.child1/pausedobj93",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4725,7 +4721,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn38.child1/pausedobj99",
+                              "actor": "server2.conn6.child1/pausedobj94",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4744,7 +4740,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn38.child1/pausedobj100",
+                              "actor": "server2.conn6.child1/pausedobj95",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4776,7 +4772,7 @@
                     "value": {
                       "type": "object",
                       "class": "HTMLDocument",
-                      "actor": "server2.conn38.child1/pausedobj101",
+                      "actor": "server2.conn6.child1/pausedobj96",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4796,7 +4792,7 @@
                     "value": {
                       "type": "object",
                       "class": "HTMLHtmlElement",
-                      "actor": "server2.conn38.child1/pausedobj102",
+                      "actor": "server2.conn6.child1/pausedobj97",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4836,7 +4832,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj103",
+                      "actor": "server2.conn6.child1/pausedobj98",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4911,7 +4907,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj104",
+                      "actor": "server2.conn6.child1/pausedobj99",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4929,7 +4925,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj105",
+                      "actor": "server2.conn6.child1/pausedobj100",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4947,7 +4943,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj106",
+                      "actor": "server2.conn6.child1/pausedobj101",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4966,7 +4962,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj107",
+                      "actor": "server2.conn6.child1/pausedobj102",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4984,7 +4980,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj108",
+                      "actor": "server2.conn6.child1/pausedobj103",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5000,7 +4996,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj109",
+                      "actor": "server2.conn6.child1/pausedobj104",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5018,7 +5014,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj110",
+                      "actor": "server2.conn6.child1/pausedobj105",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5034,7 +5030,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj111",
+                      "actor": "server2.conn6.child1/pausedobj106",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5056,7 +5052,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj112",
+                      "actor": "server2.conn6.child1/pausedobj107",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5071,7 +5067,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj113",
+                      "actor": "server2.conn6.child1/pausedobj108",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5086,7 +5082,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj114",
+                      "actor": "server2.conn6.child1/pausedobj109",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5101,7 +5097,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj115",
+                      "actor": "server2.conn6.child1/pausedobj110",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5116,7 +5112,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj116",
+                      "actor": "server2.conn6.child1/pausedobj111",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5131,7 +5127,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj117",
+                      "actor": "server2.conn6.child1/pausedobj112",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5153,7 +5149,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj118",
+                      "actor": "server2.conn6.child1/pausedobj113",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5172,7 +5168,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj119",
+                      "actor": "server2.conn6.child1/pausedobj114",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5194,7 +5190,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj120",
+                      "actor": "server2.conn6.child1/pausedobj115",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5209,7 +5205,7 @@
                             "value": {
                               "type": "object",
                               "class": "Object",
-                              "actor": "server2.conn38.child1/pausedobj121",
+                              "actor": "server2.conn6.child1/pausedobj116",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -5223,7 +5219,7 @@
                             "value": {
                               "type": "object",
                               "class": "Object",
-                              "actor": "server2.conn38.child1/pausedobj122",
+                              "actor": "server2.conn6.child1/pausedobj117",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -5243,7 +5239,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj123",
+                      "actor": "server2.conn6.child1/pausedobj118",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5265,7 +5261,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj124",
+                      "actor": "server2.conn6.child1/pausedobj119",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5280,7 +5276,7 @@
                             "value": {
                               "type": "object",
                               "class": "Object",
-                              "actor": "server2.conn38.child1/pausedobj125",
+                              "actor": "server2.conn6.child1/pausedobj120",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -5295,7 +5291,7 @@
                             "configurable": true,
                             "enumerable": true,
                             "writable": true,
-                            "value": "jQuery20309241865866128040.43034317485030704"
+                            "value": "jQuery203059027818202741270.24574955802811005"
                           }
                         },
                         "ownPropertiesLength": 2,
@@ -5310,7 +5306,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj126",
+                      "actor": "server2.conn6.child1/pausedobj121",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5325,14 +5321,14 @@
                             "value": {
                               "type": "object",
                               "class": "Object",
-                              "actor": "server2.conn38.child1/pausedobj127",
+                              "actor": "server2.conn6.child1/pausedobj122",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
-                              "ownPropertyLength": 14,
+                              "ownPropertyLength": 17,
                               "preview": {
                                 "kind": "ArrayLike",
-                                "length": 14
+                                "length": 17
                               }
                             }
                           },
@@ -5340,7 +5336,7 @@
                             "configurable": true,
                             "enumerable": true,
                             "writable": true,
-                            "value": "jQuery20309241865866128040.5040131599394156"
+                            "value": "jQuery203059027818202741270.8790218811926621"
                           }
                         },
                         "ownPropertiesLength": 2,
@@ -5355,7 +5351,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj128",
+                      "actor": "server2.conn6.child1/pausedobj123",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5370,7 +5366,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj129",
+                      "actor": "server2.conn6.child1/pausedobj124",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5385,7 +5381,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj130",
+                      "actor": "server2.conn6.child1/pausedobj125",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5405,7 +5401,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj131",
+                      "actor": "server2.conn6.child1/pausedobj126",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5437,7 +5433,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj132",
+                      "actor": "server2.conn6.child1/pausedobj127",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5452,7 +5448,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn38.child1/pausedobj133",
+                              "actor": "server2.conn6.child1/pausedobj128",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -5481,7 +5477,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj134",
+                      "actor": "server2.conn6.child1/pausedobj129",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5496,7 +5492,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj135",
+                      "actor": "server2.conn6.child1/pausedobj130",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5511,7 +5507,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj136",
+                      "actor": "server2.conn6.child1/pausedobj131",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5526,7 +5522,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj137",
+                      "actor": "server2.conn6.child1/pausedobj132",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5541,7 +5537,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj138",
+                      "actor": "server2.conn6.child1/pausedobj133",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5556,7 +5552,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj139",
+                      "actor": "server2.conn6.child1/pausedobj134",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5571,7 +5567,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj140",
+                      "actor": "server2.conn6.child1/pausedobj135",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5586,7 +5582,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj141",
+                      "actor": "server2.conn6.child1/pausedobj136",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5606,7 +5602,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj142",
+                      "actor": "server2.conn6.child1/pausedobj137",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5626,7 +5622,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj143",
+                      "actor": "server2.conn6.child1/pausedobj138",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5646,7 +5642,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj144",
+                      "actor": "server2.conn6.child1/pausedobj139",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5661,7 +5657,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj145",
+                      "actor": "server2.conn6.child1/pausedobj140",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5676,7 +5672,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj146",
+                      "actor": "server2.conn6.child1/pausedobj141",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5691,7 +5687,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj147",
+                      "actor": "server2.conn6.child1/pausedobj142",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5736,7 +5732,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj148",
+                      "actor": "server2.conn6.child1/pausedobj143",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5759,7 +5755,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj149",
+                      "actor": "server2.conn6.child1/pausedobj144",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5783,7 +5779,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj150",
+                      "actor": "server2.conn6.child1/pausedobj145",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5798,7 +5794,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj151",
+                      "actor": "server2.conn6.child1/pausedobj146",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5813,7 +5809,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj152",
+                      "actor": "server2.conn6.child1/pausedobj147",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5828,7 +5824,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj153",
+                      "actor": "server2.conn6.child1/pausedobj148",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5843,7 +5839,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj154",
+                      "actor": "server2.conn6.child1/pausedobj149",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5858,7 +5854,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj155",
+                      "actor": "server2.conn6.child1/pausedobj150",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5873,7 +5869,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj156",
+                      "actor": "server2.conn6.child1/pausedobj151",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5888,7 +5884,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj157",
+                      "actor": "server2.conn6.child1/pausedobj152",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5903,7 +5899,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj158",
+                      "actor": "server2.conn6.child1/pausedobj153",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5918,7 +5914,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj159",
+                      "actor": "server2.conn6.child1/pausedobj154",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5933,7 +5929,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj160",
+                              "actor": "server2.conn6.child1/pausedobj155",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -5951,7 +5947,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj161",
+                              "actor": "server2.conn6.child1/pausedobj156",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -5969,7 +5965,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj162",
+                              "actor": "server2.conn6.child1/pausedobj157",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -5987,7 +5983,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj163",
+                              "actor": "server2.conn6.child1/pausedobj158",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -6005,7 +6001,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj164",
+                              "actor": "server2.conn6.child1/pausedobj159",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -6023,7 +6019,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj165",
+                              "actor": "server2.conn6.child1/pausedobj160",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -6041,7 +6037,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj160",
+                              "actor": "server2.conn6.child1/pausedobj155",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -6059,7 +6055,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj161",
+                              "actor": "server2.conn6.child1/pausedobj156",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -6077,7 +6073,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj161",
+                              "actor": "server2.conn6.child1/pausedobj156",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -6095,7 +6091,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj161",
+                              "actor": "server2.conn6.child1/pausedobj156",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -6118,7 +6114,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj166",
+                      "actor": "server2.conn6.child1/pausedobj161",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6141,7 +6137,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj167",
+                      "actor": "server2.conn6.child1/pausedobj162",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6163,7 +6159,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj168",
+                      "actor": "server2.conn6.child1/pausedobj163",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6185,7 +6181,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj169",
+                      "actor": "server2.conn6.child1/pausedobj164",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6208,7 +6204,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj170",
+                      "actor": "server2.conn6.child1/pausedobj165",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6231,7 +6227,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj171",
+                      "actor": "server2.conn6.child1/pausedobj166",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6254,7 +6250,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj172",
+                      "actor": "server2.conn6.child1/pausedobj167",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6277,7 +6273,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj173",
+                      "actor": "server2.conn6.child1/pausedobj168",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6308,7 +6304,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj174",
+                      "actor": "server2.conn6.child1/pausedobj169",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6323,7 +6319,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj175",
+                      "actor": "server2.conn6.child1/pausedobj170",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6338,7 +6334,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj176",
+                      "actor": "server2.conn6.child1/pausedobj171",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6353,7 +6349,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj177",
+                      "actor": "server2.conn6.child1/pausedobj172",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6368,7 +6364,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj178",
+                      "actor": "server2.conn6.child1/pausedobj173",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6383,7 +6379,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj179",
+                      "actor": "server2.conn6.child1/pausedobj174",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6410,7 +6406,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj180",
+                      "actor": "server2.conn6.child1/pausedobj175",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6449,7 +6445,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj181",
+                      "actor": "server2.conn6.child1/pausedobj176",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6482,7 +6478,7 @@
                     "value": {
                       "type": "object",
                       "class": "Array",
-                      "actor": "server2.conn38.child1/pausedobj182",
+                      "actor": "server2.conn6.child1/pausedobj177",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6506,7 +6502,7 @@
                     "value": {
                       "type": "object",
                       "class": "Array",
-                      "actor": "server2.conn38.child1/pausedobj183",
+                      "actor": "server2.conn6.child1/pausedobj178",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6530,7 +6526,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj184",
+                      "actor": "server2.conn6.child1/pausedobj179",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6553,7 +6549,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj185",
+                      "actor": "server2.conn6.child1/pausedobj180",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6576,7 +6572,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj186",
+                      "actor": "server2.conn6.child1/pausedobj181",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6598,7 +6594,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj187",
+                      "actor": "server2.conn6.child1/pausedobj182",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6621,7 +6617,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj188",
+                      "actor": "server2.conn6.child1/pausedobj183",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6645,7 +6641,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj189",
+                      "actor": "server2.conn6.child1/pausedobj184",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6671,7 +6667,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj190",
+                      "actor": "server2.conn6.child1/pausedobj185",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6695,7 +6691,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj191",
+                      "actor": "server2.conn6.child1/pausedobj186",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6717,7 +6713,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj192",
+                      "actor": "server2.conn6.child1/pausedobj187",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6740,7 +6736,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj193",
+                      "actor": "server2.conn6.child1/pausedobj188",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6755,7 +6751,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj194",
+                      "actor": "server2.conn6.child1/pausedobj189",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6770,7 +6766,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj195",
+                      "actor": "server2.conn6.child1/pausedobj190",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6785,7 +6781,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj196",
+                      "actor": "server2.conn6.child1/pausedobj191",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6800,7 +6796,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj197",
+                      "actor": "server2.conn6.child1/pausedobj192",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6815,7 +6811,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj198",
+                      "actor": "server2.conn6.child1/pausedobj193",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6840,7 +6836,7 @@
                     "value": {
                       "type": "object",
                       "class": "Array",
-                      "actor": "server2.conn38.child1/pausedobj199",
+                      "actor": "server2.conn6.child1/pausedobj194",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6867,7 +6863,7 @@
                   "ajax_nonce": {
                     "enumerable": true,
                     "configurable": false,
-                    "value": 1467818191372,
+                    "value": 1467821724735,
                     "writable": true
                   },
                   "ajax_rquery": {
@@ -6876,7 +6872,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj200",
+                      "actor": "server2.conn6.child1/pausedobj195",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6891,7 +6887,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj201",
+                      "actor": "server2.conn6.child1/pausedobj196",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6906,7 +6902,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj202",
+                      "actor": "server2.conn6.child1/pausedobj197",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6921,7 +6917,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj203",
+                      "actor": "server2.conn6.child1/pausedobj198",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6936,7 +6932,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj204",
+                      "actor": "server2.conn6.child1/pausedobj199",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6951,7 +6947,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj205",
+                      "actor": "server2.conn6.child1/pausedobj200",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6966,7 +6962,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj206",
+                      "actor": "server2.conn6.child1/pausedobj201",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6981,7 +6977,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj207",
+                      "actor": "server2.conn6.child1/pausedobj202",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7003,7 +6999,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj208",
+                      "actor": "server2.conn6.child1/pausedobj203",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7018,7 +7014,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj209",
+                              "actor": "server2.conn6.child1/pausedobj204",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -7036,7 +7032,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj210",
+                              "actor": "server2.conn6.child1/pausedobj205",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -7054,7 +7050,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj211",
+                              "actor": "server2.conn6.child1/pausedobj206",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -7078,7 +7074,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj212",
+                      "actor": "server2.conn6.child1/pausedobj207",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7093,7 +7089,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj213",
+                              "actor": "server2.conn6.child1/pausedobj208",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -7111,7 +7107,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj214",
+                              "actor": "server2.conn6.child1/pausedobj209",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -7141,7 +7137,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj215",
+                      "actor": "server2.conn6.child1/pausedobj210",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7166,7 +7162,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj216",
+                      "actor": "server2.conn6.child1/pausedobj211",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7189,7 +7185,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj217",
+                      "actor": "server2.conn6.child1/pausedobj212",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7213,7 +7209,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj218",
+                      "actor": "server2.conn6.child1/pausedobj213",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7238,7 +7234,7 @@
                     "value": {
                       "type": "object",
                       "class": "Array",
-                      "actor": "server2.conn38.child1/pausedobj219",
+                      "actor": "server2.conn6.child1/pausedobj214",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7257,7 +7253,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj220",
+                      "actor": "server2.conn6.child1/pausedobj215",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7278,7 +7274,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj221",
+                      "actor": "server2.conn6.child1/pausedobj216",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7317,7 +7313,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj222",
+                      "actor": "server2.conn6.child1/pausedobj217",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7353,7 +7349,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj223",
+                      "actor": "server2.conn6.child1/pausedobj218",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7368,7 +7364,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj224",
+                      "actor": "server2.conn6.child1/pausedobj219",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7383,7 +7379,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn38.child1/pausedobj225",
+                      "actor": "server2.conn6.child1/pausedobj220",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7398,7 +7394,7 @@
                     "value": {
                       "type": "object",
                       "class": "Array",
-                      "actor": "server2.conn38.child1/pausedobj226",
+                      "actor": "server2.conn6.child1/pausedobj221",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7410,7 +7406,7 @@
                           {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn38.child1/pausedobj227",
+                            "actor": "server2.conn6.child1/pausedobj222",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -7437,7 +7433,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn38.child1/pausedobj228",
+                      "actor": "server2.conn6.child1/pausedobj223",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7452,7 +7448,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn38.child1/pausedobj229",
+                              "actor": "server2.conn6.child1/pausedobj224",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -7476,7 +7472,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj230",
+                      "actor": "server2.conn6.child1/pausedobj225",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7496,7 +7492,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj231",
+                      "actor": "server2.conn6.child1/pausedobj226",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7520,7 +7516,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj232",
+                      "actor": "server2.conn6.child1/pausedobj227",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7544,7 +7540,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj233",
+                      "actor": "server2.conn6.child1/pausedobj228",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7567,7 +7563,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj234",
+                      "actor": "server2.conn6.child1/pausedobj229",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7593,7 +7589,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj235",
+                      "actor": "server2.conn6.child1/pausedobj230",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7616,7 +7612,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj236",
+                      "actor": "server2.conn6.child1/pausedobj231",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7701,7 +7697,7 @@
             "function": {
               "type": "object",
               "class": "Function",
-              "actor": "server2.conn38.child1/pausedobj255",
+              "actor": "server2.conn6.child1/pausedobj250",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -7792,7 +7788,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj256",
+                    "actor": "server2.conn6.child1/pausedobj251",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -7912,7 +7908,7 @@
           "function": {
             "type": "object",
             "class": "Function",
-            "actor": "server2.conn38.child1/pausedobj256",
+            "actor": "server2.conn6.child1/pausedobj251",
             "extensible": true,
             "frozen": false,
             "sealed": false,
@@ -7934,7 +7930,7 @@
                   "value": {
                     "type": "object",
                     "class": "Event",
-                    "actor": "server2.conn38.child1/pausedobj257",
+                    "actor": "server2.conn6.child1/pausedobj252",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -7947,7 +7943,7 @@
                         "currentTarget": {
                           "type": "object",
                           "class": "HTMLLIElement",
-                          "actor": "server2.conn38.child1/pausedobj77",
+                          "actor": "server2.conn6.child1/pausedobj72",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -7966,11 +7962,11 @@
                         "bubbles": true,
                         "cancelable": false,
                         "defaultPrevented": false,
-                        "timeStamp": 1467818195619794,
+                        "timeStamp": 1467821730772228,
                         "originalTarget": {
                           "type": "object",
                           "class": "HTMLInputElement",
-                          "actor": "server2.conn38.child1/pausedobj240",
+                          "actor": "server2.conn6.child1/pausedobj235",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -7981,7 +7977,7 @@
                             "nodeName": "input",
                             "attributes": {
                               "class": "edit",
-                              "value": "hitherethere"
+                              "value": "hitheretheretheretherethere"
                             },
                             "attributesLength": 2
                           }
@@ -7989,7 +7985,7 @@
                         "explicitOriginalTarget": {
                           "type": "object",
                           "class": "HTMLInputElement",
-                          "actor": "server2.conn38.child1/pausedobj240",
+                          "actor": "server2.conn6.child1/pausedobj235",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -8000,7 +7996,7 @@
                             "nodeName": "input",
                             "attributes": {
                               "class": "edit",
-                              "value": "hitherethere"
+                              "value": "hitheretheretheretherethere"
                             },
                             "attributesLength": 2
                           }
@@ -8010,7 +8006,7 @@
                       "target": {
                         "type": "object",
                         "class": "HTMLInputElement",
-                        "actor": "server2.conn38.child1/pausedobj240",
+                        "actor": "server2.conn6.child1/pausedobj235",
                         "extensible": true,
                         "frozen": false,
                         "sealed": false,
@@ -8021,7 +8017,7 @@
                           "nodeName": "input",
                           "attributes": {
                             "class": "edit",
-                            "value": "hitherethere"
+                            "value": "hitheretheretheretherethere"
                           },
                           "attributesLength": 2
                         }
@@ -8039,7 +8035,7 @@
                 "value": {
                   "type": "object",
                   "class": "Arguments",
-                  "actor": "server2.conn38.child1/pausedobj258",
+                  "actor": "server2.conn6.child1/pausedobj253",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -8058,39 +8054,39 @@
         }
       },
       {
-        "id": "server2.conn38.child1/259",
+        "id": "server2.conn6.child1/254",
         "displayName": "sendKey",
         "location": {
-          "sourceId": "server2.conn38.child1/54",
+          "sourceId": "server2.conn6.child1/48",
           "line": 68,
           "column": 5
         },
         "scope": {
-          "actor": "server2.conn38.child1/261",
+          "actor": "server2.conn6.child1/256",
           "type": "function",
           "parent": {
-            "actor": "server2.conn38.child1/262",
+            "actor": "server2.conn6.child1/257",
             "type": "function",
             "parent": {
-              "actor": "server2.conn38.child1/263",
+              "actor": "server2.conn6.child1/258",
               "type": "block",
               "parent": {
-                "actor": "server2.conn38.child1/264",
+                "actor": "server2.conn6.child1/259",
                 "type": "with",
                 "parent": {
-                  "actor": "server2.conn38.child1/65",
+                  "actor": "server2.conn6.child1/60",
                   "type": "block",
                   "parent": {
-                    "actor": "server2.conn38.child1/66",
+                    "actor": "server2.conn6.child1/61",
                     "type": "object",
                     "object": {
                       "type": "object",
                       "class": "Window",
-                      "actor": "server2.conn38.child1/pausedobj67",
+                      "actor": "server2.conn6.child1/pausedobj62",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
-                      "ownPropertyLength": 783,
+                      "ownPropertyLength": 785,
                       "preview": {
                         "kind": "ObjectWithURL",
                         "url": "http://localhost:8000/todomvc/"
@@ -8105,7 +8101,7 @@
                 "object": {
                   "type": "object",
                   "class": "Object",
-                  "actor": "server2.conn38.child1/pausedobj265",
+                  "actor": "server2.conn6.child1/pausedobj260",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -8127,7 +8123,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj266",
+                      "actor": "server2.conn6.child1/pausedobj261",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -8147,7 +8143,7 @@
             "function": {
               "type": "object",
               "class": "Function",
-              "actor": "server2.conn38.child1/pausedobj266",
+              "actor": "server2.conn6.child1/pausedobj261",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -8177,7 +8173,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj267",
+                    "actor": "server2.conn6.child1/pausedobj262",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8199,7 +8195,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj268",
+                    "actor": "server2.conn6.child1/pausedobj263",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8221,7 +8217,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj269",
+                    "actor": "server2.conn6.child1/pausedobj264",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8243,7 +8239,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj270",
+                    "actor": "server2.conn6.child1/pausedobj265",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8266,7 +8262,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj271",
+                    "actor": "server2.conn6.child1/pausedobj266",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8289,7 +8285,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj272",
+                    "actor": "server2.conn6.child1/pausedobj267",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8312,7 +8308,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj273",
+                    "actor": "server2.conn6.child1/pausedobj268",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8366,7 +8362,7 @@
           "function": {
             "type": "object",
             "class": "Function",
-            "actor": "server2.conn38.child1/pausedobj272",
+            "actor": "server2.conn6.child1/pausedobj267",
             "extensible": true,
             "frozen": false,
             "sealed": false,
@@ -8390,7 +8386,7 @@
                   "value": {
                     "type": "object",
                     "class": "HTMLInputElement",
-                    "actor": "server2.conn38.child1/pausedobj274",
+                    "actor": "server2.conn6.child1/pausedobj269",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8401,7 +8397,7 @@
                       "nodeName": "input",
                       "attributes": {
                         "class": "edit",
-                        "value": "hitherethere"
+                        "value": "hitheretheretheretherethere"
                       },
                       "attributesLength": 2
                     }
@@ -8425,7 +8421,7 @@
                 "value": {
                   "type": "object",
                   "class": "Arguments",
-                  "actor": "server2.conn38.child1/pausedobj275",
+                  "actor": "server2.conn6.child1/pausedobj270",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -8444,39 +8440,39 @@
         }
       },
       {
-        "id": "server2.conn38.child1/277",
+        "id": "server2.conn6.child1/272",
         "displayName": "type",
         "location": {
-          "sourceId": "server2.conn38.child1/54",
+          "sourceId": "server2.conn6.child1/48",
           "line": 93,
           "column": 7
         },
         "scope": {
-          "actor": "server2.conn38.child1/279",
+          "actor": "server2.conn6.child1/274",
           "type": "function",
           "parent": {
-            "actor": "server2.conn38.child1/262",
+            "actor": "server2.conn6.child1/257",
             "type": "function",
             "parent": {
-              "actor": "server2.conn38.child1/263",
+              "actor": "server2.conn6.child1/258",
               "type": "block",
               "parent": {
-                "actor": "server2.conn38.child1/264",
+                "actor": "server2.conn6.child1/259",
                 "type": "with",
                 "parent": {
-                  "actor": "server2.conn38.child1/65",
+                  "actor": "server2.conn6.child1/60",
                   "type": "block",
                   "parent": {
-                    "actor": "server2.conn38.child1/66",
+                    "actor": "server2.conn6.child1/61",
                     "type": "object",
                     "object": {
                       "type": "object",
                       "class": "Window",
-                      "actor": "server2.conn38.child1/pausedobj67",
+                      "actor": "server2.conn6.child1/pausedobj62",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
-                      "ownPropertyLength": 783,
+                      "ownPropertyLength": 785,
                       "preview": {
                         "kind": "ObjectWithURL",
                         "url": "http://localhost:8000/todomvc/"
@@ -8491,7 +8487,7 @@
                 "object": {
                   "type": "object",
                   "class": "Object",
-                  "actor": "server2.conn38.child1/pausedobj265",
+                  "actor": "server2.conn6.child1/pausedobj260",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -8513,7 +8509,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn38.child1/pausedobj266",
+                      "actor": "server2.conn6.child1/pausedobj261",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -8533,7 +8529,7 @@
             "function": {
               "type": "object",
               "class": "Function",
-              "actor": "server2.conn38.child1/pausedobj266",
+              "actor": "server2.conn6.child1/pausedobj261",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -8563,7 +8559,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj267",
+                    "actor": "server2.conn6.child1/pausedobj262",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8585,7 +8581,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj268",
+                    "actor": "server2.conn6.child1/pausedobj263",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8607,7 +8603,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj269",
+                    "actor": "server2.conn6.child1/pausedobj264",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8629,7 +8625,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj270",
+                    "actor": "server2.conn6.child1/pausedobj265",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8652,7 +8648,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj271",
+                    "actor": "server2.conn6.child1/pausedobj266",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8675,7 +8671,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn38.child1/pausedobj272",
+                    "actor": "server2.conn6.child1/pausedobj267",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8698,7 +8694,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn38.child1/pausedobj273",
+                    "actor": "server2.conn6.child1/pausedobj268",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8752,7 +8748,7 @@
           "function": {
             "type": "object",
             "class": "Function",
-            "actor": "server2.conn38.child1/pausedobj280",
+            "actor": "server2.conn6.child1/pausedobj275",
             "extensible": true,
             "frozen": false,
             "sealed": false,
@@ -8793,7 +8789,7 @@
                 "value": {
                   "type": "object",
                   "class": "Arguments",
-                  "actor": "server2.conn38.child1/pausedobj281",
+                  "actor": "server2.conn6.child1/pausedobj276",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -8813,7 +8809,7 @@
                 "value": {
                   "type": "object",
                   "class": "HTMLInputElement",
-                  "actor": "server2.conn38.child1/pausedobj282",
+                  "actor": "server2.conn6.child1/pausedobj277",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -8824,7 +8820,7 @@
                     "nodeName": "input",
                     "attributes": {
                       "class": "edit",
-                      "value": "hitherethere"
+                      "value": "hitheretheretheretherethere"
                     },
                     "attributesLength": 2
                   }
@@ -8836,30 +8832,30 @@
         }
       },
       {
-        "id": "server2.conn38.child1/286",
+        "id": "server2.conn6.child1/281",
         "displayName": "(global)",
         "location": {
-          "sourceId": "server2.conn38.child1/59",
+          "sourceId": "server2.conn6.child1/54",
           "line": 3,
           "column": 4
         },
         "scope": {
-          "actor": "server2.conn38.child1/287",
+          "actor": "server2.conn6.child1/282",
           "type": "with",
           "parent": {
-            "actor": "server2.conn38.child1/65",
+            "actor": "server2.conn6.child1/60",
             "type": "block",
             "parent": {
-              "actor": "server2.conn38.child1/66",
+              "actor": "server2.conn6.child1/61",
               "type": "object",
               "object": {
                 "type": "object",
                 "class": "Window",
-                "actor": "server2.conn38.child1/pausedobj67",
+                "actor": "server2.conn6.child1/pausedobj62",
                 "extensible": true,
                 "frozen": false,
                 "sealed": false,
-                "ownPropertyLength": 783,
+                "ownPropertyLength": 785,
                 "preview": {
                   "kind": "ObjectWithURL",
                   "url": "http://localhost:8000/todomvc/"
@@ -8874,7 +8870,7 @@
           "object": {
             "type": "object",
             "class": "Object",
-            "actor": "server2.conn38.child1/pausedobj288",
+            "actor": "server2.conn6.child1/pausedobj283",
             "extensible": true,
             "frozen": false,
             "sealed": false,
@@ -8890,33 +8886,33 @@
       }
     ],
     "selectedFrame": {
-      "id": "server2.conn38.child1/61",
+      "id": "server2.conn6.child1/56",
       "displayName": "app.TodoView<.updateOnEnter",
       "location": {
-        "sourceId": "server2.conn38.child1/36",
+        "sourceId": "server2.conn6.child1/36",
         "line": 113,
         "column": 4
       },
       "scope": {
-        "actor": "server2.conn38.child1/63",
+        "actor": "server2.conn6.child1/58",
         "type": "function",
         "parent": {
-          "actor": "server2.conn38.child1/64",
+          "actor": "server2.conn6.child1/59",
           "type": "function",
           "parent": {
-            "actor": "server2.conn38.child1/65",
+            "actor": "server2.conn6.child1/60",
             "type": "block",
             "parent": {
-              "actor": "server2.conn38.child1/66",
+              "actor": "server2.conn6.child1/61",
               "type": "object",
               "object": {
                 "type": "object",
                 "class": "Window",
-                "actor": "server2.conn38.child1/pausedobj67",
+                "actor": "server2.conn6.child1/pausedobj62",
                 "extensible": true,
                 "frozen": false,
                 "sealed": false,
-                "ownPropertyLength": 783,
+                "ownPropertyLength": 785,
                 "preview": {
                   "kind": "ObjectWithURL",
                   "url": "http://localhost:8000/todomvc/"
@@ -8931,7 +8927,7 @@
           "function": {
             "type": "object",
             "class": "Function",
-            "actor": "server2.conn38.child1/pausedobj68",
+            "actor": "server2.conn6.child1/pausedobj63",
             "extensible": true,
             "frozen": false,
             "sealed": false,
@@ -8973,7 +8969,7 @@
         "function": {
           "type": "object",
           "class": "Function",
-          "actor": "server2.conn38.child1/pausedobj69",
+          "actor": "server2.conn6.child1/pausedobj64",
           "extensible": true,
           "frozen": false,
           "sealed": false,
@@ -8995,7 +8991,7 @@
                 "value": {
                   "type": "object",
                   "class": "Object",
-                  "actor": "server2.conn38.child1/pausedobj70",
+                  "actor": "server2.conn6.child1/pausedobj65",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -9010,7 +9006,7 @@
                         "value": {
                           "type": "object",
                           "class": "Event",
-                          "actor": "server2.conn38.child1/pausedobj71",
+                          "actor": "server2.conn6.child1/pausedobj66",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -9024,7 +9020,7 @@
                               "bubbles": true,
                               "cancelable": false,
                               "defaultPrevented": false,
-                              "timeStamp": 1467818195619794,
+                              "timeStamp": 1467821730772228,
                               "NONE": 0,
                               "CAPTURING_PHASE": 1,
                               "AT_TARGET": 2,
@@ -9046,7 +9042,7 @@
                         "value": {
                           "type": "object",
                           "class": "Function",
-                          "actor": "server2.conn38.child1/pausedobj72",
+                          "actor": "server2.conn6.child1/pausedobj67",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -9063,9 +9059,9 @@
                         "configurable": true,
                         "enumerable": true,
                         "writable": true,
-                        "value": 1467818195619794
+                        "value": 1467821730772228
                       },
-                      "jQuery2030924186586612804": {
+                      "jQuery20305902781820274127": {
                         "configurable": true,
                         "enumerable": true,
                         "writable": true,
@@ -9120,7 +9116,7 @@
               "value": {
                 "type": "object",
                 "class": "Arguments",
-                "actor": "server2.conn38.child1/pausedobj73",
+                "actor": "server2.conn6.child1/pausedobj68",
                 "extensible": true,
                 "frozen": false,
                 "sealed": false,
@@ -9139,7 +9135,7 @@
       }
     },
     "loadedObjects": {
-      "server2.conn38.child1/pausedobj70": [
+      "server2.conn6.child1/pausedobj65": [
         [
           "altKey",
           {
@@ -9209,7 +9205,7 @@
             "value": {
               "type": "object",
               "class": "HTMLInputElement",
-              "actor": "server2.conn38.child1/pausedobj240",
+              "actor": "server2.conn6.child1/pausedobj235",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -9220,7 +9216,7 @@
                 "nodeName": "input",
                 "attributes": {
                   "class": "edit",
-                  "value": "hitherethere"
+                  "value": "hitheretheretheretherethere"
                 },
                 "attributesLength": 2
               }
@@ -9247,7 +9243,7 @@
             "value": {
               "type": "object",
               "class": "HTMLLIElement",
-              "actor": "server2.conn38.child1/pausedobj77",
+              "actor": "server2.conn6.child1/pausedobj72",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -9282,7 +9278,7 @@
             "value": {
               "type": "object",
               "class": "Object",
-              "actor": "server2.conn38.child1/pausedobj248",
+              "actor": "server2.conn6.child1/pausedobj243",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -9315,14 +9311,14 @@
                     "enumerable": true,
                     "writable": true,
                     "value": {
+                      "type": "object",
+                      "class": "Function",
+                      "actor": "server2.conn6.child1/pausedobj238",
+                      "extensible": true,
                       "frozen": false,
+                      "sealed": false,
                       "name": "bound updateOnEnter",
                       "displayName": "bound updateOnEnter",
-                      "actor": "server2.conn38.child1/pausedobj243",
-                      "class": "Function",
-                      "type": "object",
-                      "extensible": true,
-                      "sealed": false,
                       "parameterNames": []
                     }
                   },
@@ -9348,7 +9344,7 @@
                     "configurable": true,
                     "enumerable": true,
                     "writable": true,
-                    "value": "delegateEventsview10"
+                    "value": "delegateEventsview13"
                   }
                 },
                 "ownPropertiesLength": 8,
@@ -9364,24 +9360,24 @@
             "enumerable": true,
             "writable": true,
             "value": {
+              "type": "object",
+              "class": "Function",
+              "actor": "server2.conn6.child1/pausedobj67",
+              "extensible": true,
               "frozen": false,
+              "sealed": false,
               "name": "returnFalse",
               "displayName": "returnFalse",
-              "actor": "server2.conn38.child1/pausedobj72",
+              "parameterNames": [],
               "location": {
                 "url": "http://localhost:8000/todomvc/bower_components/jquery/jquery.js",
                 "line": 4309
-              },
-              "class": "Function",
-              "type": "object",
-              "extensible": true,
-              "sealed": false,
-              "parameterNames": []
+              }
             }
           }
         ],
         [
-          "jQuery2030924186586612804",
+          "jQuery20305902781820274127",
           {
             "configurable": true,
             "enumerable": true,
@@ -9429,7 +9425,7 @@
             "value": {
               "type": "object",
               "class": "Event",
-              "actor": "server2.conn38.child1/pausedobj71",
+              "actor": "server2.conn6.child1/pausedobj66",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -9438,31 +9434,11 @@
                 "kind": "DOMEvent",
                 "type": "keypress",
                 "properties": {
-                  "eventPhase": 3,
-                  "originalTarget": {
-                    "type": "object",
-                    "class": "HTMLInputElement",
-                    "actor": "server2.conn38.child1/pausedobj240",
-                    "extensible": true,
-                    "frozen": false,
-                    "sealed": false,
-                    "ownPropertyLength": 0,
-                    "preview": {
-                      "kind": "DOMNode",
-                      "nodeType": 1,
-                      "nodeName": "input",
-                      "attributes": {
-                        "class": "edit",
-                        "value": "hitherethere"
-                      },
-                      "attributesLength": 2
-                    }
-                  },
-                  "bubbles": true,
+                  "isTrusted": false,
                   "currentTarget": {
                     "type": "object",
                     "class": "HTMLLIElement",
-                    "actor": "server2.conn38.child1/pausedobj77",
+                    "actor": "server2.conn6.child1/pausedobj72",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -9477,13 +9453,15 @@
                       "attributesLength": 1
                     }
                   },
-                  "isTrusted": false,
+                  "eventPhase": 3,
+                  "bubbles": true,
                   "cancelable": false,
-                  "timeStamp": 1467818195619794,
-                  "explicitOriginalTarget": {
+                  "defaultPrevented": false,
+                  "timeStamp": 1467821730772228,
+                  "originalTarget": {
                     "type": "object",
                     "class": "HTMLInputElement",
-                    "actor": "server2.conn38.child1/pausedobj240",
+                    "actor": "server2.conn6.child1/pausedobj235",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -9494,18 +9472,36 @@
                       "nodeName": "input",
                       "attributes": {
                         "class": "edit",
-                        "value": "hitherethere"
+                        "value": "hitheretheretheretherethere"
                       },
                       "attributesLength": 2
                     }
                   },
-                  "defaultPrevented": false,
+                  "explicitOriginalTarget": {
+                    "type": "object",
+                    "class": "HTMLInputElement",
+                    "actor": "server2.conn6.child1/pausedobj235",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "ownPropertyLength": 0,
+                    "preview": {
+                      "kind": "DOMNode",
+                      "nodeType": 1,
+                      "nodeName": "input",
+                      "attributes": {
+                        "class": "edit",
+                        "value": "hitheretheretheretherethere"
+                      },
+                      "attributesLength": 2
+                    }
+                  },
                   "NONE": 0
                 },
                 "target": {
                   "type": "object",
                   "class": "HTMLInputElement",
-                  "actor": "server2.conn38.child1/pausedobj240",
+                  "actor": "server2.conn6.child1/pausedobj235",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -9516,7 +9512,7 @@
                     "nodeName": "input",
                     "attributes": {
                       "class": "edit",
-                      "value": "hitherethere"
+                      "value": "hitheretheretheretherethere"
                     },
                     "attributesLength": 2
                   }
@@ -9556,7 +9552,7 @@
             "value": {
               "type": "object",
               "class": "HTMLInputElement",
-              "actor": "server2.conn38.child1/pausedobj240",
+              "actor": "server2.conn6.child1/pausedobj235",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -9567,7 +9563,7 @@
                 "nodeName": "input",
                 "attributes": {
                   "class": "edit",
-                  "value": "hitherethere"
+                  "value": "hitheretheretheretherethere"
                 },
                 "attributesLength": 2
               }
@@ -9580,7 +9576,7 @@
             "configurable": true,
             "enumerable": true,
             "writable": true,
-            "value": 1467818195619794
+            "value": 1467821730772228
           }
         ],
         [

--- a/public/js/test/fixtures/todomvc.updateOnEnter.json
+++ b/public/js/test/fixtures/todomvc.updateOnEnter.json
@@ -112,6 +112,28 @@
         "loading": false,
         "id": "server2.conn120.50",
         "text": "this.close();"
+      },
+      "server2.conn120.source42:142": {
+        "location": {
+          "sourceId": "server2.conn120.source42",
+          "line": 142
+        },
+        "condition": null,
+        "disabled": false,
+        "loading": false,
+        "id": "server2.conn120.50",
+        "text": "return undefined;"
+      },
+      "server2.conn120.source42:169": {
+        "location": {
+          "sourceId": "server2.conn120.source42",
+          "line": 169
+        },
+        "condition": null,
+        "disabled": true,
+        "loading": false,
+        "id": "server2.conn120.50",
+        "text": "var name = text.toLowerCase();"
       }
     }
   },

--- a/public/js/test/fixtures/todomvc.updateOnEnter.json
+++ b/public/js/test/fixtures/todomvc.updateOnEnter.json
@@ -6,77 +6,77 @@
   },
   "sources": {
     "sources": {
-      "server2.conn120.source40": {
-        "id": "server2.conn120.source40",
-        "url": "http://localhost:8000/todomvc/js/models/todo.js"
-      },
-      "server2.conn120.source51": {
-        "id": "server2.conn120.source51",
+      "server2.conn38.child1/59": {
+        "id": "server2.conn38.child1/59",
         "url": null
       },
-      "server2.conn120.source62": {
-        "id": "server2.conn120.source62",
+      "server2.conn38.child1/37": {
+        "id": "server2.conn38.child1/37",
         "url": null
       },
-      "server2.conn120.source41": {
-        "id": "server2.conn120.source41",
-        "url": "http://localhost:8000/todomvc/js/collections/todos.js"
-      },
-      "server2.conn120.source42": {
-        "id": "server2.conn120.source42",
-        "url": "http://localhost:8000/todomvc/js/views/todo-view.js"
-      },
-      "server2.conn120.source43": {
-        "id": "server2.conn120.source43",
+      "server2.conn38.child1/48": {
+        "id": "server2.conn38.child1/48",
         "url": null
       },
-      "server2.conn120.source44": {
-        "id": "server2.conn120.source44",
+      "server2.conn38.child1/38": {
+        "id": "server2.conn38.child1/38",
         "url": "http://localhost:8000/todomvc/js/views/app-view.js"
       },
-      "server2.conn120.source45": {
-        "id": "server2.conn120.source45",
-        "url": null
-      },
-      "server2.conn120.source56": {
-        "id": "server2.conn120.source56",
-        "url": null
-      },
-      "server2.conn120.source35": {
-        "id": "server2.conn120.source35",
-        "url": "http://localhost:8000/todomvc/bower_components/todomvc-common/base.js"
-      },
-      "server2.conn120.source46": {
-        "id": "server2.conn120.source46",
-        "url": "http://localhost:8000/todomvc/js/routers/router.js"
-      },
-      "server2.conn120.source57": {
-        "id": "server2.conn120.source57",
-        "url": null
-      },
-      "server2.conn120.source36": {
-        "id": "server2.conn120.source36",
-        "url": "http://localhost:8000/todomvc/bower_components/jquery/jquery.js"
-      },
-      "server2.conn120.source47": {
-        "id": "server2.conn120.source47",
-        "url": "http://localhost:8000/todomvc/js/app.js"
-      },
-      "server2.conn120.source37": {
-        "id": "server2.conn120.source37",
-        "url": "http://localhost:8000/todomvc/bower_components/underscore/underscore.js"
-      },
-      "server2.conn120.source48": {
-        "id": "server2.conn120.source48",
+      "server2.conn38.child1/28": {
+        "id": "server2.conn38.child1/28",
         "url": "http://localhost:8000/todomvc/"
       },
-      "server2.conn120.source38": {
-        "id": "server2.conn120.source38",
+      "server2.conn38.child1/39": {
+        "id": "server2.conn38.child1/39",
+        "url": null
+      },
+      "server2.conn38.child1/29": {
+        "id": "server2.conn38.child1/29",
+        "url": "http://localhost:8000/todomvc/bower_components/todomvc-common/base.js"
+      },
+      "server2.conn38.child1/40": {
+        "id": "server2.conn38.child1/40",
+        "url": "http://localhost:8000/todomvc/js/routers/router.js"
+      },
+      "server2.conn38.child1/30": {
+        "id": "server2.conn38.child1/30",
+        "url": "http://localhost:8000/todomvc/bower_components/jquery/jquery.js"
+      },
+      "server2.conn38.child1/41": {
+        "id": "server2.conn38.child1/41",
+        "url": "http://localhost:8000/todomvc/js/app.js"
+      },
+      "server2.conn38.child1/31": {
+        "id": "server2.conn38.child1/31",
+        "url": "http://localhost:8000/todomvc/bower_components/underscore/underscore.js"
+      },
+      "server2.conn38.child1/53": {
+        "id": "server2.conn38.child1/53",
+        "url": null
+      },
+      "server2.conn38.child1/32": {
+        "id": "server2.conn38.child1/32",
         "url": "http://localhost:8000/todomvc/bower_components/backbone/backbone.js"
       },
-      "server2.conn120.source39": {
-        "id": "server2.conn120.source39",
+      "server2.conn38.child1/54": {
+        "id": "server2.conn38.child1/54",
+        "url": null
+      },
+      "server2.conn38.child1/33": {
+        "id": "server2.conn38.child1/33",
         "url": "http://localhost:8000/todomvc/bower_components/backbone.localStorage/backbone.localStorage.js"
+      },
+      "server2.conn38.child1/34": {
+        "id": "server2.conn38.child1/34",
+        "url": "http://localhost:8000/todomvc/js/models/todo.js"
+      },
+      "server2.conn38.child1/35": {
+        "id": "server2.conn38.child1/35",
+        "url": "http://localhost:8000/todomvc/js/collections/todos.js"
+      },
+      "server2.conn38.child1/36": {
+        "id": "server2.conn38.child1/36",
+        "url": "http://localhost:8000/todomvc/js/views/todo-view.js"
       }
     },
     "sourceTree": [
@@ -84,56 +84,56 @@
       []
     ],
     "selectedSource": {
-      "id": "server2.conn120.source42",
+      "id": "server2.conn38.child1/36",
       "url": "http://localhost:8000/todomvc/js/views/todo-view.js"
     },
     "sourcesText": {
-      "server2.conn120.source42": {
+      "server2.conn38.child1/36": {
         "text": "/*global Backbone, jQuery, _, ENTER_KEY, ESC_KEY */\nvar app = app || {};\n\n(function ($) {\n\t'use strict';\n\n\t// Todo Item View\n\t// --------------\n\n\t// The DOM element for a todo item...\n\tapp.TodoView = Backbone.View.extend({\n\t\t//... is a list tag.\n\t\ttagName:  'li',\n\n\t\t// Cache the template function for a single item.\n\t\ttemplate: _.template($('#item-template').html()),\n\n\t\t// The DOM events specific to an item.\n\t\tevents: {\n\t\t\t'click .toggle': 'toggleCompleted',\n\t\t\t'dblclick label': 'edit',\n\t\t\t'click .destroy': 'clear',\n\t\t\t'keypress .edit': 'updateOnEnter',\n\t\t\t'keydown .edit': 'revertOnEscape',\n\t\t\t'blur .edit': 'close'\n\t\t},\n\n\t\t// The TodoView listens for changes to its model, re-rendering. Since\n\t\t// there's a one-to-one correspondence between a **Todo** and a\n\t\t// **TodoView** in this app, we set a direct reference on the model for\n\t\t// convenience.\n\t\tinitialize: function () {\n\t\t\tthis.listenTo(this.model, 'change', this.render);\n\t\t\tthis.listenTo(this.model, 'destroy', this.remove);\n\t\t\tthis.listenTo(this.model, 'visible', this.toggleVisible);\n\t\t},\n\n\t\t// Re-render the titles of the todo item.\n\t\trender: function () {\n\t\t\t// Backbone LocalStorage is adding `id` attribute instantly after\n\t\t\t// creating a model.  This causes our TodoView to render twice. Once\n\t\t\t// after creating a model and once on `id` change.  We want to\n\t\t\t// filter out the second redundant render, which is caused by this\n\t\t\t// `id` change.  It's known Backbone LocalStorage bug, therefore\n\t\t\t// we've to create a workaround.\n\t\t\t// https://github.com/tastejs/todomvc/issues/469\n\t\t\tif (this.model.changed.id !== undefined) {\n\t\t\t\treturn;\n\t\t\t}\n\n\t\t\tthis.$el.html(this.template(this.model.toJSON()));\n\t\t\tthis.$el.toggleClass('completed', this.model.get('completed'));\n\t\t\tthis.toggleVisible();\n\t\t\tthis.$input = this.$('.edit');\n\t\t\treturn this;\n\t\t},\n\n\t\ttoggleVisible: function () {\n\t\t\tthis.$el.toggleClass('hidden', this.isHidden());\n\t\t},\n\n\t\tisHidden: function () {\n\t\t\treturn this.model.get('completed') ?\n\t\t\t\tapp.TodoFilter === 'active' :\n\t\t\t\tapp.TodoFilter === 'completed';\n\t\t},\n\n\t\t// Toggle the `\"completed\"` state of the model.\n\t\ttoggleCompleted: function () {\n\t\t\tthis.model.toggle();\n\t\t},\n\n\t\t// Switch this view into `\"editing\"` mode, displaying the input field.\n\t\tedit: function () {\n\t\t\tthis.$el.addClass('editing');\n\t\t\tthis.$input.focus();\n\t\t},\n\n\t\t// Close the `\"editing\"` mode, saving changes to the todo.\n\t\tclose: function () {\n\t\t\tvar value = this.$input.val();\n\t\t\tvar trimmedValue = value.trim();\n\n\t\t\t// We don't want to handle blur events from an item that is no\n\t\t\t// longer being edited. Relying on the CSS class here has the\n\t\t\t// benefit of us not having to maintain state in the DOM and the\n\t\t\t// JavaScript logic.\n\t\t\tif (!this.$el.hasClass('editing')) {\n\t\t\t\treturn;\n\t\t\t}\n\n\t\t\tif (trimmedValue) {\n\t\t\t\tthis.model.save({ title: trimmedValue });\n\n\t\t\t\tif (value !== trimmedValue) {\n\t\t\t\t\t// Model values changes consisting of whitespaces only are\n\t\t\t\t\t// not causing change to be triggered Therefore we've to\n\t\t\t\t\t// compare untrimmed version with a trimmed one to check\n\t\t\t\t\t// whether anything changed\n\t\t\t\t\t// And if yes, we've to trigger change event ourselves\n\t\t\t\t\tthis.model.trigger('change');\n\t\t\t\t}\n\t\t\t} else {\n\t\t\t\tthis.clear();\n\t\t\t}\n\n\t\t\tthis.$el.removeClass('editing');\n\t\t},\n\n\t\t// If you hit `enter`, we're through editing the item.\n\t\tupdateOnEnter: function (e) {\n\t\t\tif (e.which === ENTER_KEY) {\n\t\t\t\tthis.close();\n\t\t\t}\n\t\t},\n\n\t\t// If you're pressing `escape` we revert your change by simply leaving\n\t\t// the `editing` state.\n\t\trevertOnEscape: function (e) {\n\t\t\tif (e.which === ESC_KEY) {\n\t\t\t\tthis.$el.removeClass('editing');\n\t\t\t\t// Also reset the hidden input back to the original value.\n\t\t\t\tthis.$input.val(this.model.get('title'));\n\t\t\t}\n\t\t},\n\n\t\t// Remove the item, destroy the model from *localStorage* and delete its view.\n\t\tclear: function () {\n\t\t\tthis.model.destroy();\n\t\t}\n\t});\n})(jQuery);\n",
         "contentType": "text/javascript"
       }
     },
     "tabs": [
       {
-        "id": "server2.conn120.source42",
+        "id": "server2.conn38.child1/36",
         "url": "http://localhost:8000/todomvc/js/views/todo-view.js"
       }
     ]
   },
   "breakpoints": {
     "breakpoints": {
-      "server2.conn120.source42:113": {
+      "server2.conn38.child1/36:113": {
         "location": {
-          "sourceId": "server2.conn120.source42",
+          "sourceId": "server2.conn38.child1/36",
           "line": 113
         },
         "condition": null,
         "disabled": false,
         "loading": false,
-        "id": "server2.conn120.50",
+        "id": "server2.conn38.child1/43",
         "text": "this.close();"
       },
-      "server2.conn120.source42:142": {
+      "server2.conn38.child1/36:119": {
         "location": {
-          "sourceId": "server2.conn120.source42",
-          "line": 142
+          "sourceId": "server2.conn38.child1/36",
+          "line": 119
         },
         "condition": null,
         "disabled": false,
         "loading": false,
-        "id": "server2.conn120.50",
-        "text": "return undefined;"
+        "id": "server2.conn38.child1/45",
+        "text": "revertOnEscape: function (e) {"
       },
-      "server2.conn120.source42:169": {
+      "server2.conn38.child1/36:121": {
         "location": {
-          "sourceId": "server2.conn120.source42",
-          "line": 169
+          "sourceId": "server2.conn38.child1/36",
+          "line": 121
         },
         "condition": null,
         "disabled": true,
         "loading": false,
-        "id": "server2.conn120.50",
-        "text": "var name = text.toLowerCase();"
+        "id": "server2.conn38.child1/47",
+        "text": "this.$el.removeClass('editing');"
       }
     }
   },
@@ -144,37 +144,37 @@
   },
   "pause": {
     "pause": {
-      "from": "server2.conn120.context33",
+      "from": "server2.conn38.child1/26",
       "type": "paused",
-      "actor": "server2.conn120.pause63",
+      "actor": "server2.conn38.child1/pause60",
       "frame": {
-        "id": "server2.conn120.64",
+        "id": "server2.conn38.child1/61",
         "displayName": "app.TodoView<.updateOnEnter",
         "location": {
-          "sourceId": "server2.conn120.source42",
+          "sourceId": "server2.conn38.child1/36",
           "line": 113,
-          "column": 17
+          "column": 4
         },
         "scope": {
-          "actor": "server2.conn120.environment66",
+          "actor": "server2.conn38.child1/63",
           "type": "function",
           "parent": {
-            "actor": "server2.conn120.environment67",
+            "actor": "server2.conn38.child1/64",
             "type": "function",
             "parent": {
-              "actor": "server2.conn120.environment68",
+              "actor": "server2.conn38.child1/65",
               "type": "block",
               "parent": {
-                "actor": "server2.conn120.environment69",
+                "actor": "server2.conn38.child1/66",
                 "type": "object",
                 "object": {
                   "type": "object",
                   "class": "Window",
-                  "actor": "server2.conn120.pausedobj70",
+                  "actor": "server2.conn38.child1/pausedobj67",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
-                  "ownPropertyLength": 734,
+                  "ownPropertyLength": 783,
                   "preview": {
                     "kind": "ObjectWithURL",
                     "url": "http://localhost:8000/todomvc/"
@@ -189,7 +189,7 @@
             "function": {
               "type": "object",
               "class": "Function",
-              "actor": "server2.conn120.pausedobj71",
+              "actor": "server2.conn38.child1/pausedobj68",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -231,7 +231,7 @@
           "function": {
             "frozen": false,
             "displayName": "app.TodoView<.updateOnEnter",
-            "actor": "server2.conn120.pausedobj72",
+            "actor": "server2.conn38.child1/pausedobj69",
             "location": {
               "url": "http://localhost:8000/todomvc/js/views/todo-view.js",
               "line": 111
@@ -253,7 +253,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj73",
+                    "actor": "server2.conn38.child1/pausedobj70",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -269,7 +269,7 @@
                             "frozen": false,
                             "name": "returnFalse",
                             "displayName": "returnFalse",
-                            "actor": "server2.conn120.pausedobj75",
+                            "actor": "server2.conn38.child1/pausedobj72",
                             "location": {
                               "url": "http://localhost:8000/todomvc/bower_components/jquery/jquery.js",
                               "line": 4309
@@ -294,7 +294,7 @@
                           "value": {
                             "type": "object",
                             "class": "Event",
-                            "actor": "server2.conn120.pausedobj74",
+                            "actor": "server2.conn38.child1/pausedobj71",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -308,7 +308,7 @@
                                 "bubbles": true,
                                 "isTrusted": false,
                                 "cancelable": false,
-                                "timeStamp": 1466546401646235,
+                                "timeStamp": 1467818195619794,
                                 "defaultPrevented": false,
                                 "NONE": 0,
                                 "AT_TARGET": 2,
@@ -317,17 +317,23 @@
                             }
                           }
                         },
+                        "jQuery2030924186586612804": {
+                          "configurable": true,
+                          "enumerable": true,
+                          "writable": true,
+                          "value": true
+                        },
                         "keyCode": {
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": 84
+                          "value": 13
                         },
                         "timeStamp": {
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": 1466546401646235
+                          "value": 1467818195619794
                         },
                         "char": {
                           "configurable": true,
@@ -347,13 +353,7 @@
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": 84
-                        },
-                        "jQuery2030059558816119138824": {
-                          "configurable": true,
-                          "enumerable": true,
-                          "writable": true,
-                          "value": true
+                          "value": 13
                         },
                         "key": {
                           "configurable": true,
@@ -378,7 +378,7 @@
                 "value": {
                   "type": "object",
                   "class": "Arguments",
-                  "actor": "server2.conn120.pausedobj76",
+                  "actor": "server2.conn38.child1/pausedobj73",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -400,7 +400,7 @@
       "why": {
         "type": "breakpoint",
         "actors": [
-          "server2.conn120.50"
+          "server2.conn38.child1/43"
         ]
       },
       "isInterrupted": false
@@ -408,33 +408,33 @@
     "isWaitingOnBreak": false,
     "frames": [
       {
-        "id": "server2.conn120.64",
+        "id": "server2.conn38.child1/61",
         "displayName": "app.TodoView<.updateOnEnter",
         "location": {
-          "sourceId": "server2.conn120.source42",
+          "sourceId": "server2.conn38.child1/36",
           "line": 113,
-          "column": 17
+          "column": 4
         },
         "scope": {
-          "actor": "server2.conn120.environment66",
+          "actor": "server2.conn38.child1/63",
           "type": "function",
           "parent": {
-            "actor": "server2.conn120.environment67",
+            "actor": "server2.conn38.child1/64",
             "type": "function",
             "parent": {
-              "actor": "server2.conn120.environment68",
+              "actor": "server2.conn38.child1/65",
               "type": "block",
               "parent": {
-                "actor": "server2.conn120.environment69",
+                "actor": "server2.conn38.child1/66",
                 "type": "object",
                 "object": {
                   "type": "object",
                   "class": "Window",
-                  "actor": "server2.conn120.pausedobj70",
+                  "actor": "server2.conn38.child1/pausedobj67",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
-                  "ownPropertyLength": 734,
+                  "ownPropertyLength": 783,
                   "preview": {
                     "kind": "ObjectWithURL",
                     "url": "http://localhost:8000/todomvc/"
@@ -449,7 +449,7 @@
             "function": {
               "type": "object",
               "class": "Function",
-              "actor": "server2.conn120.pausedobj71",
+              "actor": "server2.conn38.child1/pausedobj68",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -491,7 +491,7 @@
           "function": {
             "type": "object",
             "class": "Function",
-            "actor": "server2.conn120.pausedobj72",
+            "actor": "server2.conn38.child1/pausedobj69",
             "extensible": true,
             "frozen": false,
             "sealed": false,
@@ -513,7 +513,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj73",
+                    "actor": "server2.conn38.child1/pausedobj70",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -528,7 +528,7 @@
                           "value": {
                             "type": "object",
                             "class": "Event",
-                            "actor": "server2.conn120.pausedobj74",
+                            "actor": "server2.conn38.child1/pausedobj71",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -542,7 +542,7 @@
                                 "bubbles": true,
                                 "cancelable": false,
                                 "defaultPrevented": false,
-                                "timeStamp": 1466546401646235,
+                                "timeStamp": 1467818195619794,
                                 "NONE": 0,
                                 "CAPTURING_PHASE": 1,
                                 "AT_TARGET": 2,
@@ -564,7 +564,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn120.pausedobj75",
+                            "actor": "server2.conn38.child1/pausedobj72",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -581,9 +581,9 @@
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": 1466546401646235
+                          "value": 1467818195619794
                         },
-                        "jQuery2030059558816119138824": {
+                        "jQuery2030924186586612804": {
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
@@ -593,7 +593,7 @@
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": 84
+                          "value": 13
                         },
                         "key": {
                           "configurable": true,
@@ -621,7 +621,7 @@
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": 84
+                          "value": 13
                         }
                       },
                       "ownPropertiesLength": 24
@@ -638,7 +638,7 @@
                 "value": {
                   "type": "object",
                   "class": "Arguments",
-                  "actor": "server2.conn120.pausedobj84",
+                  "actor": "server2.conn38.child1/pausedobj81",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -657,33 +657,33 @@
         }
       },
       {
-        "id": "server2.conn120.85",
+        "id": "server2.conn38.child1/82",
         "displayName": "jQuery.event.dispatch",
         "location": {
-          "sourceId": "server2.conn120.source36",
+          "sourceId": "server2.conn38.child1/30",
           "line": 4675,
           "column": 14
         },
         "scope": {
-          "actor": "server2.conn120.environment87",
+          "actor": "server2.conn38.child1/84",
           "type": "function",
           "parent": {
-            "actor": "server2.conn120.environment88",
+            "actor": "server2.conn38.child1/85",
             "type": "function",
             "parent": {
-              "actor": "server2.conn120.environment68",
+              "actor": "server2.conn38.child1/65",
               "type": "block",
               "parent": {
-                "actor": "server2.conn120.environment69",
+                "actor": "server2.conn38.child1/66",
                 "type": "object",
                 "object": {
                   "type": "object",
                   "class": "Window",
-                  "actor": "server2.conn120.pausedobj70",
+                  "actor": "server2.conn38.child1/pausedobj67",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
-                  "ownPropertyLength": 734,
+                  "ownPropertyLength": 783,
                   "preview": {
                     "kind": "ObjectWithURL",
                     "url": "http://localhost:8000/todomvc/"
@@ -698,7 +698,7 @@
             "function": {
               "type": "object",
               "class": "Function",
-              "actor": "server2.conn120.pausedobj89",
+              "actor": "server2.conn38.child1/pausedobj86",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -720,11 +720,11 @@
                     "value": {
                       "type": "object",
                       "class": "Window",
-                      "actor": "server2.conn120.pausedobj90",
+                      "actor": "server2.conn38.child1/pausedobj87",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
-                      "ownPropertyLength": 734,
+                      "ownPropertyLength": 783,
                       "preview": {
                         "kind": "ObjectWithURL",
                         "url": "http://localhost:8000/todomvc/"
@@ -760,7 +760,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj91",
+                    "actor": "server2.conn38.child1/pausedobj88",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -775,7 +775,7 @@
                           "value": {
                             "type": "object",
                             "class": "HTMLDocument",
-                            "actor": "server2.conn120.pausedobj92",
+                            "actor": "server2.conn38.child1/pausedobj89",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -807,7 +807,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj93",
+                    "actor": "server2.conn38.child1/pausedobj90",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -822,7 +822,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn120.pausedobj94",
+                            "actor": "server2.conn38.child1/pausedobj91",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -841,7 +841,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn120.pausedobj95",
+                            "actor": "server2.conn38.child1/pausedobj92",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -863,7 +863,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn120.pausedobj96",
+                            "actor": "server2.conn38.child1/pausedobj93",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -882,7 +882,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn120.pausedobj97",
+                            "actor": "server2.conn38.child1/pausedobj94",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -904,7 +904,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn120.pausedobj98",
+                            "actor": "server2.conn38.child1/pausedobj95",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -923,7 +923,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn120.pausedobj99",
+                            "actor": "server2.conn38.child1/pausedobj96",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -945,7 +945,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn120.pausedobj100",
+                            "actor": "server2.conn38.child1/pausedobj97",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -964,7 +964,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn120.pausedobj101",
+                            "actor": "server2.conn38.child1/pausedobj98",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -983,7 +983,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn120.pausedobj102",
+                            "actor": "server2.conn38.child1/pausedobj99",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -1002,7 +1002,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn120.pausedobj103",
+                            "actor": "server2.conn38.child1/pausedobj100",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -1034,7 +1034,7 @@
                   "value": {
                     "type": "object",
                     "class": "HTMLDocument",
-                    "actor": "server2.conn120.pausedobj104",
+                    "actor": "server2.conn38.child1/pausedobj101",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1054,7 +1054,7 @@
                   "value": {
                     "type": "object",
                     "class": "HTMLHtmlElement",
-                    "actor": "server2.conn120.pausedobj105",
+                    "actor": "server2.conn38.child1/pausedobj102",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1064,11 +1064,10 @@
                       "nodeType": 1,
                       "nodeName": "html",
                       "attributes": {
-                        "lang": "en",
                         "data-framework": "backbonejs",
-                        "webdriver": "true"
+                        "lang": "en"
                       },
-                      "attributesLength": 3
+                      "attributesLength": 2
                     }
                   },
                   "writable": true
@@ -1095,7 +1094,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj106",
+                    "actor": "server2.conn38.child1/pausedobj103",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1170,14 +1169,14 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj107",
+                    "actor": "server2.conn38.child1/pausedobj104",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
                     "name": "concat",
                     "displayName": "concat",
                     "parameterNames": [
-                      null
+                      "arg1"
                     ]
                   },
                   "writable": true
@@ -1188,7 +1187,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj108",
+                    "actor": "server2.conn38.child1/pausedobj105",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1206,7 +1205,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj109",
+                    "actor": "server2.conn38.child1/pausedobj106",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1225,7 +1224,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj110",
+                    "actor": "server2.conn38.child1/pausedobj107",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1243,7 +1242,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj111",
+                    "actor": "server2.conn38.child1/pausedobj108",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1259,7 +1258,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj112",
+                    "actor": "server2.conn38.child1/pausedobj109",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1277,7 +1276,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj113",
+                    "actor": "server2.conn38.child1/pausedobj110",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1293,7 +1292,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj114",
+                    "actor": "server2.conn38.child1/pausedobj111",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1315,7 +1314,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj115",
+                    "actor": "server2.conn38.child1/pausedobj112",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1330,7 +1329,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj116",
+                    "actor": "server2.conn38.child1/pausedobj113",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1345,7 +1344,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj117",
+                    "actor": "server2.conn38.child1/pausedobj114",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1360,7 +1359,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj118",
+                    "actor": "server2.conn38.child1/pausedobj115",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1375,7 +1374,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj119",
+                    "actor": "server2.conn38.child1/pausedobj116",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1390,7 +1389,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj120",
+                    "actor": "server2.conn38.child1/pausedobj117",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1412,7 +1411,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj121",
+                    "actor": "server2.conn38.child1/pausedobj118",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1431,7 +1430,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj122",
+                    "actor": "server2.conn38.child1/pausedobj119",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1453,7 +1452,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj123",
+                    "actor": "server2.conn38.child1/pausedobj120",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1468,7 +1467,7 @@
                           "value": {
                             "type": "object",
                             "class": "Object",
-                            "actor": "server2.conn120.pausedobj124",
+                            "actor": "server2.conn38.child1/pausedobj121",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -1482,7 +1481,7 @@
                           "value": {
                             "type": "object",
                             "class": "Object",
-                            "actor": "server2.conn120.pausedobj125",
+                            "actor": "server2.conn38.child1/pausedobj122",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -1502,7 +1501,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj126",
+                    "actor": "server2.conn38.child1/pausedobj123",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1524,7 +1523,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj127",
+                    "actor": "server2.conn38.child1/pausedobj124",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1539,7 +1538,7 @@
                           "value": {
                             "type": "object",
                             "class": "Object",
-                            "actor": "server2.conn120.pausedobj128",
+                            "actor": "server2.conn38.child1/pausedobj125",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -1554,7 +1553,7 @@
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": "jQuery20300595588161191388240.2707580070551159"
+                          "value": "jQuery20309241865866128040.43034317485030704"
                         }
                       },
                       "ownPropertiesLength": 2,
@@ -1569,7 +1568,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj129",
+                    "actor": "server2.conn38.child1/pausedobj126",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1584,14 +1583,14 @@
                           "value": {
                             "type": "object",
                             "class": "Object",
-                            "actor": "server2.conn120.pausedobj130",
+                            "actor": "server2.conn38.child1/pausedobj127",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
-                            "ownPropertyLength": 32,
+                            "ownPropertyLength": 14,
                             "preview": {
                               "kind": "ArrayLike",
-                              "length": 32
+                              "length": 14
                             }
                           }
                         },
@@ -1599,7 +1598,7 @@
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": "jQuery20300595588161191388240.1484088228123488"
+                          "value": "jQuery20309241865866128040.5040131599394156"
                         }
                       },
                       "ownPropertiesLength": 2,
@@ -1614,7 +1613,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj131",
+                    "actor": "server2.conn38.child1/pausedobj128",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1629,7 +1628,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj132",
+                    "actor": "server2.conn38.child1/pausedobj129",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1644,7 +1643,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj133",
+                    "actor": "server2.conn38.child1/pausedobj130",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1664,7 +1663,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj134",
+                    "actor": "server2.conn38.child1/pausedobj131",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1696,7 +1695,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj135",
+                    "actor": "server2.conn38.child1/pausedobj132",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1711,7 +1710,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn120.pausedobj136",
+                            "actor": "server2.conn38.child1/pausedobj133",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -1740,7 +1739,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj137",
+                    "actor": "server2.conn38.child1/pausedobj134",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1755,7 +1754,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj138",
+                    "actor": "server2.conn38.child1/pausedobj135",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1770,7 +1769,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj139",
+                    "actor": "server2.conn38.child1/pausedobj136",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1785,7 +1784,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj140",
+                    "actor": "server2.conn38.child1/pausedobj137",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1800,7 +1799,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj141",
+                    "actor": "server2.conn38.child1/pausedobj138",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1815,7 +1814,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj142",
+                    "actor": "server2.conn38.child1/pausedobj139",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1830,7 +1829,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj143",
+                    "actor": "server2.conn38.child1/pausedobj140",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1845,7 +1844,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj144",
+                    "actor": "server2.conn38.child1/pausedobj141",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1865,7 +1864,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj145",
+                    "actor": "server2.conn38.child1/pausedobj142",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1885,7 +1884,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj146",
+                    "actor": "server2.conn38.child1/pausedobj143",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1905,7 +1904,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj147",
+                    "actor": "server2.conn38.child1/pausedobj144",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1920,7 +1919,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj148",
+                    "actor": "server2.conn38.child1/pausedobj145",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1935,7 +1934,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj149",
+                    "actor": "server2.conn38.child1/pausedobj146",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1950,7 +1949,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj150",
+                    "actor": "server2.conn38.child1/pausedobj147",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -1995,7 +1994,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj151",
+                    "actor": "server2.conn38.child1/pausedobj148",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2018,7 +2017,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj152",
+                    "actor": "server2.conn38.child1/pausedobj149",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2042,7 +2041,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj153",
+                    "actor": "server2.conn38.child1/pausedobj150",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2057,7 +2056,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj154",
+                    "actor": "server2.conn38.child1/pausedobj151",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2072,7 +2071,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj155",
+                    "actor": "server2.conn38.child1/pausedobj152",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2087,7 +2086,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj156",
+                    "actor": "server2.conn38.child1/pausedobj153",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2102,7 +2101,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj157",
+                    "actor": "server2.conn38.child1/pausedobj154",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2117,7 +2116,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj158",
+                    "actor": "server2.conn38.child1/pausedobj155",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2132,7 +2131,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj159",
+                    "actor": "server2.conn38.child1/pausedobj156",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2147,7 +2146,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj160",
+                    "actor": "server2.conn38.child1/pausedobj157",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2162,7 +2161,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj161",
+                    "actor": "server2.conn38.child1/pausedobj158",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2177,7 +2176,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj162",
+                    "actor": "server2.conn38.child1/pausedobj159",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2192,7 +2191,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj163",
+                            "actor": "server2.conn38.child1/pausedobj160",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2210,7 +2209,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj164",
+                            "actor": "server2.conn38.child1/pausedobj161",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2228,7 +2227,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj165",
+                            "actor": "server2.conn38.child1/pausedobj162",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2246,7 +2245,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj166",
+                            "actor": "server2.conn38.child1/pausedobj163",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2264,7 +2263,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj167",
+                            "actor": "server2.conn38.child1/pausedobj164",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2282,7 +2281,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj168",
+                            "actor": "server2.conn38.child1/pausedobj165",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2300,7 +2299,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj163",
+                            "actor": "server2.conn38.child1/pausedobj160",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2318,7 +2317,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj164",
+                            "actor": "server2.conn38.child1/pausedobj161",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2336,7 +2335,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj164",
+                            "actor": "server2.conn38.child1/pausedobj161",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2354,7 +2353,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj164",
+                            "actor": "server2.conn38.child1/pausedobj161",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -2377,7 +2376,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj169",
+                    "actor": "server2.conn38.child1/pausedobj166",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2400,7 +2399,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj170",
+                    "actor": "server2.conn38.child1/pausedobj167",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2422,7 +2421,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj171",
+                    "actor": "server2.conn38.child1/pausedobj168",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2444,7 +2443,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj172",
+                    "actor": "server2.conn38.child1/pausedobj169",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2467,7 +2466,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj173",
+                    "actor": "server2.conn38.child1/pausedobj170",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2490,7 +2489,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj174",
+                    "actor": "server2.conn38.child1/pausedobj171",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2513,7 +2512,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj175",
+                    "actor": "server2.conn38.child1/pausedobj172",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2536,7 +2535,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj176",
+                    "actor": "server2.conn38.child1/pausedobj173",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2567,7 +2566,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj177",
+                    "actor": "server2.conn38.child1/pausedobj174",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2582,7 +2581,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj178",
+                    "actor": "server2.conn38.child1/pausedobj175",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2597,7 +2596,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj179",
+                    "actor": "server2.conn38.child1/pausedobj176",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2612,7 +2611,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj180",
+                    "actor": "server2.conn38.child1/pausedobj177",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2627,7 +2626,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj181",
+                    "actor": "server2.conn38.child1/pausedobj178",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2642,7 +2641,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj182",
+                    "actor": "server2.conn38.child1/pausedobj179",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2669,7 +2668,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj183",
+                    "actor": "server2.conn38.child1/pausedobj180",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2708,7 +2707,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj184",
+                    "actor": "server2.conn38.child1/pausedobj181",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2741,7 +2740,7 @@
                   "value": {
                     "type": "object",
                     "class": "Array",
-                    "actor": "server2.conn120.pausedobj185",
+                    "actor": "server2.conn38.child1/pausedobj182",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2765,7 +2764,7 @@
                   "value": {
                     "type": "object",
                     "class": "Array",
-                    "actor": "server2.conn120.pausedobj186",
+                    "actor": "server2.conn38.child1/pausedobj183",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2789,7 +2788,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj187",
+                    "actor": "server2.conn38.child1/pausedobj184",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2812,7 +2811,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj188",
+                    "actor": "server2.conn38.child1/pausedobj185",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2835,7 +2834,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj189",
+                    "actor": "server2.conn38.child1/pausedobj186",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2857,7 +2856,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj190",
+                    "actor": "server2.conn38.child1/pausedobj187",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2880,7 +2879,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj191",
+                    "actor": "server2.conn38.child1/pausedobj188",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2904,7 +2903,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj192",
+                    "actor": "server2.conn38.child1/pausedobj189",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2930,7 +2929,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj193",
+                    "actor": "server2.conn38.child1/pausedobj190",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2954,7 +2953,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj194",
+                    "actor": "server2.conn38.child1/pausedobj191",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2976,7 +2975,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj195",
+                    "actor": "server2.conn38.child1/pausedobj192",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -2999,7 +2998,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj196",
+                    "actor": "server2.conn38.child1/pausedobj193",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3014,7 +3013,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj197",
+                    "actor": "server2.conn38.child1/pausedobj194",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3029,7 +3028,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj198",
+                    "actor": "server2.conn38.child1/pausedobj195",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3044,7 +3043,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj199",
+                    "actor": "server2.conn38.child1/pausedobj196",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3059,7 +3058,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj200",
+                    "actor": "server2.conn38.child1/pausedobj197",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3074,7 +3073,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj201",
+                    "actor": "server2.conn38.child1/pausedobj198",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3099,7 +3098,7 @@
                   "value": {
                     "type": "object",
                     "class": "Array",
-                    "actor": "server2.conn120.pausedobj202",
+                    "actor": "server2.conn38.child1/pausedobj199",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3126,7 +3125,7 @@
                 "ajax_nonce": {
                   "enumerable": true,
                   "configurable": false,
-                  "value": 1466546398350,
+                  "value": 1467818191372,
                   "writable": true
                 },
                 "ajax_rquery": {
@@ -3135,7 +3134,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj203",
+                    "actor": "server2.conn38.child1/pausedobj200",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3150,7 +3149,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj204",
+                    "actor": "server2.conn38.child1/pausedobj201",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3165,7 +3164,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj205",
+                    "actor": "server2.conn38.child1/pausedobj202",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3180,7 +3179,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj206",
+                    "actor": "server2.conn38.child1/pausedobj203",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3195,7 +3194,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj207",
+                    "actor": "server2.conn38.child1/pausedobj204",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3210,7 +3209,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj208",
+                    "actor": "server2.conn38.child1/pausedobj205",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3225,7 +3224,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj209",
+                    "actor": "server2.conn38.child1/pausedobj206",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3240,7 +3239,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj210",
+                    "actor": "server2.conn38.child1/pausedobj207",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3262,7 +3261,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj211",
+                    "actor": "server2.conn38.child1/pausedobj208",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3277,7 +3276,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj212",
+                            "actor": "server2.conn38.child1/pausedobj209",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -3295,7 +3294,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj213",
+                            "actor": "server2.conn38.child1/pausedobj210",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -3313,7 +3312,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj214",
+                            "actor": "server2.conn38.child1/pausedobj211",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -3337,7 +3336,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj215",
+                    "actor": "server2.conn38.child1/pausedobj212",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3352,7 +3351,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj216",
+                            "actor": "server2.conn38.child1/pausedobj213",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -3370,7 +3369,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj217",
+                            "actor": "server2.conn38.child1/pausedobj214",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -3400,7 +3399,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj218",
+                    "actor": "server2.conn38.child1/pausedobj215",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3425,7 +3424,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj219",
+                    "actor": "server2.conn38.child1/pausedobj216",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3448,7 +3447,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj220",
+                    "actor": "server2.conn38.child1/pausedobj217",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3472,7 +3471,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj221",
+                    "actor": "server2.conn38.child1/pausedobj218",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3497,7 +3496,7 @@
                   "value": {
                     "type": "object",
                     "class": "Array",
-                    "actor": "server2.conn120.pausedobj222",
+                    "actor": "server2.conn38.child1/pausedobj219",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3516,7 +3515,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj223",
+                    "actor": "server2.conn38.child1/pausedobj220",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3537,7 +3536,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj224",
+                    "actor": "server2.conn38.child1/pausedobj221",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3576,7 +3575,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj225",
+                    "actor": "server2.conn38.child1/pausedobj222",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3612,7 +3611,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj226",
+                    "actor": "server2.conn38.child1/pausedobj223",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3627,7 +3626,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj227",
+                    "actor": "server2.conn38.child1/pausedobj224",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3642,7 +3641,7 @@
                   "value": {
                     "type": "object",
                     "class": "RegExp",
-                    "actor": "server2.conn120.pausedobj228",
+                    "actor": "server2.conn38.child1/pausedobj225",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3657,7 +3656,7 @@
                   "value": {
                     "type": "object",
                     "class": "Array",
-                    "actor": "server2.conn120.pausedobj229",
+                    "actor": "server2.conn38.child1/pausedobj226",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3669,7 +3668,7 @@
                         {
                           "type": "object",
                           "class": "Function",
-                          "actor": "server2.conn120.pausedobj230",
+                          "actor": "server2.conn38.child1/pausedobj227",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -3696,7 +3695,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj231",
+                    "actor": "server2.conn38.child1/pausedobj228",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3711,7 +3710,7 @@
                           "value": {
                             "type": "object",
                             "class": "Array",
-                            "actor": "server2.conn120.pausedobj232",
+                            "actor": "server2.conn38.child1/pausedobj229",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -3735,7 +3734,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj233",
+                    "actor": "server2.conn38.child1/pausedobj230",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3755,7 +3754,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj234",
+                    "actor": "server2.conn38.child1/pausedobj231",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3779,7 +3778,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj235",
+                    "actor": "server2.conn38.child1/pausedobj232",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3803,7 +3802,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj236",
+                    "actor": "server2.conn38.child1/pausedobj233",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3826,7 +3825,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj237",
+                    "actor": "server2.conn38.child1/pausedobj234",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3852,7 +3851,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj238",
+                    "actor": "server2.conn38.child1/pausedobj235",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3875,7 +3874,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj239",
+                    "actor": "server2.conn38.child1/pausedobj236",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3960,7 +3959,7 @@
           "function": {
             "type": "object",
             "class": "Function",
-            "actor": "server2.conn120.pausedobj240",
+            "actor": "server2.conn38.child1/pausedobj237",
             "extensible": true,
             "frozen": false,
             "sealed": false,
@@ -3982,7 +3981,7 @@
                   "value": {
                     "type": "object",
                     "class": "Object",
-                    "actor": "server2.conn120.pausedobj241",
+                    "actor": "server2.conn38.child1/pausedobj238",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -3997,7 +3996,7 @@
                           "value": {
                             "type": "object",
                             "class": "Event",
-                            "actor": "server2.conn120.pausedobj74",
+                            "actor": "server2.conn38.child1/pausedobj71",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -4011,7 +4010,7 @@
                                 "bubbles": true,
                                 "cancelable": false,
                                 "defaultPrevented": false,
-                                "timeStamp": 1466546401646235,
+                                "timeStamp": 1467818195619794,
                                 "NONE": 0,
                                 "CAPTURING_PHASE": 1,
                                 "AT_TARGET": 2,
@@ -4033,7 +4032,7 @@
                           "value": {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn120.pausedobj75",
+                            "actor": "server2.conn38.child1/pausedobj72",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -4050,9 +4049,9 @@
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": 1466546401646235
+                          "value": 1467818195619794
                         },
-                        "jQuery2030059558816119138824": {
+                        "jQuery2030924186586612804": {
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
@@ -4062,7 +4061,7 @@
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": 84
+                          "value": 13
                         },
                         "key": {
                           "configurable": true,
@@ -4090,7 +4089,7 @@
                           "configurable": true,
                           "enumerable": true,
                           "writable": true,
-                          "value": 84
+                          "value": 13
                         }
                       },
                       "ownPropertiesLength": 24
@@ -4127,7 +4126,7 @@
                 "value": {
                   "type": "object",
                   "class": "Object",
-                  "actor": "server2.conn120.pausedobj242",
+                  "actor": "server2.conn38.child1/pausedobj239",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -4142,7 +4141,7 @@
                         "value": {
                           "type": "object",
                           "class": "HTMLInputElement",
-                          "actor": "server2.conn120.pausedobj243",
+                          "actor": "server2.conn38.child1/pausedobj240",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -4152,8 +4151,8 @@
                             "nodeType": 1,
                             "nodeName": "input",
                             "attributes": {
-                              "value": "dtheretheretheretherethere",
-                              "class": "edit"
+                              "class": "edit",
+                              "value": "hitherethere"
                             },
                             "attributesLength": 2
                           }
@@ -4166,7 +4165,7 @@
                         "value": {
                           "type": "object",
                           "class": "Array",
-                          "actor": "server2.conn120.pausedobj244",
+                          "actor": "server2.conn38.child1/pausedobj241",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -4190,7 +4189,7 @@
                 "value": {
                   "type": "object",
                   "class": "Object",
-                  "actor": "server2.conn120.pausedobj245",
+                  "actor": "server2.conn38.child1/pausedobj242",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -4225,10 +4224,12 @@
                         "value": {
                           "type": "object",
                           "class": "Function",
-                          "actor": "server2.conn120.pausedobj246",
+                          "actor": "server2.conn38.child1/pausedobj243",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
+                          "name": "bound updateOnEnter",
+                          "displayName": "bound updateOnEnter",
                           "parameterNames": []
                         }
                       },
@@ -4254,7 +4255,7 @@
                         "configurable": true,
                         "enumerable": true,
                         "writable": true,
-                        "value": "delegateEventsview28"
+                        "value": "delegateEventsview10"
                       }
                     },
                     "ownPropertiesLength": 8,
@@ -4269,7 +4270,7 @@
                 "value": {
                   "type": "object",
                   "class": "Array",
-                  "actor": "server2.conn120.pausedobj247",
+                  "actor": "server2.conn38.child1/pausedobj244",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -4281,7 +4282,7 @@
                       {
                         "type": "object",
                         "class": "Object",
-                        "actor": "server2.conn120.pausedobj248",
+                        "actor": "server2.conn38.child1/pausedobj245",
                         "extensible": true,
                         "frozen": false,
                         "sealed": false,
@@ -4298,7 +4299,7 @@
                 "value": {
                   "type": "object",
                   "class": "Array",
-                  "actor": "server2.conn120.pausedobj249",
+                  "actor": "server2.conn38.child1/pausedobj246",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -4310,7 +4311,7 @@
                       {
                         "type": "object",
                         "class": "Object",
-                        "actor": "server2.conn120.pausedobj83",
+                        "actor": "server2.conn38.child1/pausedobj80",
                         "extensible": true,
                         "frozen": false,
                         "sealed": false,
@@ -4327,7 +4328,7 @@
                 "value": {
                   "type": "object",
                   "class": "Array",
-                  "actor": "server2.conn120.pausedobj250",
+                  "actor": "server2.conn38.child1/pausedobj247",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -4339,7 +4340,7 @@
                       {
                         "type": "object",
                         "class": "Object",
-                        "actor": "server2.conn120.pausedobj251",
+                        "actor": "server2.conn38.child1/pausedobj248",
                         "extensible": true,
                         "frozen": false,
                         "sealed": false,
@@ -4356,7 +4357,7 @@
                 "value": {
                   "type": "object",
                   "class": "Object",
-                  "actor": "server2.conn120.pausedobj252",
+                  "actor": "server2.conn38.child1/pausedobj249",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -4376,7 +4377,7 @@
                 "value": {
                   "type": "object",
                   "class": "Arguments",
-                  "actor": "server2.conn120.pausedobj253",
+                  "actor": "server2.conn38.child1/pausedobj250",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -4395,36 +4396,36 @@
         }
       },
       {
-        "id": "server2.conn120.254",
+        "id": "server2.conn38.child1/251",
         "displayName": "jQuery.event.add/elemData.handle",
         "location": {
-          "sourceId": "server2.conn120.source36",
+          "sourceId": "server2.conn38.child1/30",
           "line": 4360,
           "column": 5
         },
         "scope": {
-          "actor": "server2.conn120.environment256",
+          "actor": "server2.conn38.child1/253",
           "type": "function",
           "parent": {
-            "actor": "server2.conn120.environment257",
+            "actor": "server2.conn38.child1/254",
             "type": "function",
             "parent": {
-              "actor": "server2.conn120.environment88",
+              "actor": "server2.conn38.child1/85",
               "type": "function",
               "parent": {
-                "actor": "server2.conn120.environment68",
+                "actor": "server2.conn38.child1/65",
                 "type": "block",
                 "parent": {
-                  "actor": "server2.conn120.environment69",
+                  "actor": "server2.conn38.child1/66",
                   "type": "object",
                   "object": {
                     "type": "object",
                     "class": "Window",
-                    "actor": "server2.conn120.pausedobj70",
+                    "actor": "server2.conn38.child1/pausedobj67",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
-                    "ownPropertyLength": 734,
+                    "ownPropertyLength": 783,
                     "preview": {
                       "kind": "ObjectWithURL",
                       "url": "http://localhost:8000/todomvc/"
@@ -4439,7 +4440,7 @@
               "function": {
                 "type": "object",
                 "class": "Function",
-                "actor": "server2.conn120.pausedobj89",
+                "actor": "server2.conn38.child1/pausedobj86",
                 "extensible": true,
                 "frozen": false,
                 "sealed": false,
@@ -4461,11 +4462,11 @@
                       "value": {
                         "type": "object",
                         "class": "Window",
-                        "actor": "server2.conn120.pausedobj90",
+                        "actor": "server2.conn38.child1/pausedobj87",
                         "extensible": true,
                         "frozen": false,
                         "sealed": false,
-                        "ownPropertyLength": 734,
+                        "ownPropertyLength": 783,
                         "preview": {
                           "kind": "ObjectWithURL",
                           "url": "http://localhost:8000/todomvc/"
@@ -4501,7 +4502,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj91",
+                      "actor": "server2.conn38.child1/pausedobj88",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4516,7 +4517,7 @@
                             "value": {
                               "type": "object",
                               "class": "HTMLDocument",
-                              "actor": "server2.conn120.pausedobj92",
+                              "actor": "server2.conn38.child1/pausedobj89",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4548,7 +4549,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj93",
+                      "actor": "server2.conn38.child1/pausedobj90",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4563,7 +4564,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn120.pausedobj94",
+                              "actor": "server2.conn38.child1/pausedobj91",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4582,7 +4583,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn120.pausedobj95",
+                              "actor": "server2.conn38.child1/pausedobj92",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4604,7 +4605,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn120.pausedobj96",
+                              "actor": "server2.conn38.child1/pausedobj93",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4623,7 +4624,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn120.pausedobj97",
+                              "actor": "server2.conn38.child1/pausedobj94",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4645,7 +4646,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn120.pausedobj98",
+                              "actor": "server2.conn38.child1/pausedobj95",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4664,7 +4665,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn120.pausedobj99",
+                              "actor": "server2.conn38.child1/pausedobj96",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4686,7 +4687,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn120.pausedobj100",
+                              "actor": "server2.conn38.child1/pausedobj97",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4705,7 +4706,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn120.pausedobj101",
+                              "actor": "server2.conn38.child1/pausedobj98",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4724,7 +4725,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn120.pausedobj102",
+                              "actor": "server2.conn38.child1/pausedobj99",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4743,7 +4744,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn120.pausedobj103",
+                              "actor": "server2.conn38.child1/pausedobj100",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -4775,7 +4776,7 @@
                     "value": {
                       "type": "object",
                       "class": "HTMLDocument",
-                      "actor": "server2.conn120.pausedobj104",
+                      "actor": "server2.conn38.child1/pausedobj101",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4795,7 +4796,7 @@
                     "value": {
                       "type": "object",
                       "class": "HTMLHtmlElement",
-                      "actor": "server2.conn120.pausedobj105",
+                      "actor": "server2.conn38.child1/pausedobj102",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4805,11 +4806,10 @@
                         "nodeType": 1,
                         "nodeName": "html",
                         "attributes": {
-                          "lang": "en",
                           "data-framework": "backbonejs",
-                          "webdriver": "true"
+                          "lang": "en"
                         },
-                        "attributesLength": 3
+                        "attributesLength": 2
                       }
                     },
                     "writable": true
@@ -4836,7 +4836,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj106",
+                      "actor": "server2.conn38.child1/pausedobj103",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4911,14 +4911,14 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj107",
+                      "actor": "server2.conn38.child1/pausedobj104",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
                       "name": "concat",
                       "displayName": "concat",
                       "parameterNames": [
-                        null
+                        "arg1"
                       ]
                     },
                     "writable": true
@@ -4929,7 +4929,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj108",
+                      "actor": "server2.conn38.child1/pausedobj105",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4947,7 +4947,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj109",
+                      "actor": "server2.conn38.child1/pausedobj106",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4966,7 +4966,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj110",
+                      "actor": "server2.conn38.child1/pausedobj107",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -4984,7 +4984,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj111",
+                      "actor": "server2.conn38.child1/pausedobj108",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5000,7 +5000,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj112",
+                      "actor": "server2.conn38.child1/pausedobj109",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5018,7 +5018,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj113",
+                      "actor": "server2.conn38.child1/pausedobj110",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5034,7 +5034,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj114",
+                      "actor": "server2.conn38.child1/pausedobj111",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5056,7 +5056,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj115",
+                      "actor": "server2.conn38.child1/pausedobj112",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5071,7 +5071,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj116",
+                      "actor": "server2.conn38.child1/pausedobj113",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5086,7 +5086,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj117",
+                      "actor": "server2.conn38.child1/pausedobj114",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5101,7 +5101,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj118",
+                      "actor": "server2.conn38.child1/pausedobj115",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5116,7 +5116,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj119",
+                      "actor": "server2.conn38.child1/pausedobj116",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5131,7 +5131,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj120",
+                      "actor": "server2.conn38.child1/pausedobj117",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5153,7 +5153,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj121",
+                      "actor": "server2.conn38.child1/pausedobj118",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5172,7 +5172,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj122",
+                      "actor": "server2.conn38.child1/pausedobj119",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5194,7 +5194,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj123",
+                      "actor": "server2.conn38.child1/pausedobj120",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5209,7 +5209,7 @@
                             "value": {
                               "type": "object",
                               "class": "Object",
-                              "actor": "server2.conn120.pausedobj124",
+                              "actor": "server2.conn38.child1/pausedobj121",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -5223,7 +5223,7 @@
                             "value": {
                               "type": "object",
                               "class": "Object",
-                              "actor": "server2.conn120.pausedobj125",
+                              "actor": "server2.conn38.child1/pausedobj122",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -5243,7 +5243,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj126",
+                      "actor": "server2.conn38.child1/pausedobj123",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5265,7 +5265,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj127",
+                      "actor": "server2.conn38.child1/pausedobj124",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5280,7 +5280,7 @@
                             "value": {
                               "type": "object",
                               "class": "Object",
-                              "actor": "server2.conn120.pausedobj128",
+                              "actor": "server2.conn38.child1/pausedobj125",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -5295,7 +5295,7 @@
                             "configurable": true,
                             "enumerable": true,
                             "writable": true,
-                            "value": "jQuery20300595588161191388240.2707580070551159"
+                            "value": "jQuery20309241865866128040.43034317485030704"
                           }
                         },
                         "ownPropertiesLength": 2,
@@ -5310,7 +5310,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj129",
+                      "actor": "server2.conn38.child1/pausedobj126",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5325,14 +5325,14 @@
                             "value": {
                               "type": "object",
                               "class": "Object",
-                              "actor": "server2.conn120.pausedobj130",
+                              "actor": "server2.conn38.child1/pausedobj127",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
-                              "ownPropertyLength": 32,
+                              "ownPropertyLength": 14,
                               "preview": {
                                 "kind": "ArrayLike",
-                                "length": 32
+                                "length": 14
                               }
                             }
                           },
@@ -5340,7 +5340,7 @@
                             "configurable": true,
                             "enumerable": true,
                             "writable": true,
-                            "value": "jQuery20300595588161191388240.1484088228123488"
+                            "value": "jQuery20309241865866128040.5040131599394156"
                           }
                         },
                         "ownPropertiesLength": 2,
@@ -5355,7 +5355,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj131",
+                      "actor": "server2.conn38.child1/pausedobj128",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5370,7 +5370,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj132",
+                      "actor": "server2.conn38.child1/pausedobj129",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5385,7 +5385,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj133",
+                      "actor": "server2.conn38.child1/pausedobj130",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5405,7 +5405,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj134",
+                      "actor": "server2.conn38.child1/pausedobj131",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5437,7 +5437,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj135",
+                      "actor": "server2.conn38.child1/pausedobj132",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5452,7 +5452,7 @@
                             "value": {
                               "type": "object",
                               "class": "Function",
-                              "actor": "server2.conn120.pausedobj136",
+                              "actor": "server2.conn38.child1/pausedobj133",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -5481,7 +5481,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj137",
+                      "actor": "server2.conn38.child1/pausedobj134",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5496,7 +5496,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj138",
+                      "actor": "server2.conn38.child1/pausedobj135",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5511,7 +5511,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj139",
+                      "actor": "server2.conn38.child1/pausedobj136",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5526,7 +5526,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj140",
+                      "actor": "server2.conn38.child1/pausedobj137",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5541,7 +5541,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj141",
+                      "actor": "server2.conn38.child1/pausedobj138",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5556,7 +5556,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj142",
+                      "actor": "server2.conn38.child1/pausedobj139",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5571,7 +5571,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj143",
+                      "actor": "server2.conn38.child1/pausedobj140",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5586,7 +5586,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj144",
+                      "actor": "server2.conn38.child1/pausedobj141",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5606,7 +5606,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj145",
+                      "actor": "server2.conn38.child1/pausedobj142",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5626,7 +5626,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj146",
+                      "actor": "server2.conn38.child1/pausedobj143",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5646,7 +5646,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj147",
+                      "actor": "server2.conn38.child1/pausedobj144",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5661,7 +5661,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj148",
+                      "actor": "server2.conn38.child1/pausedobj145",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5676,7 +5676,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj149",
+                      "actor": "server2.conn38.child1/pausedobj146",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5691,7 +5691,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj150",
+                      "actor": "server2.conn38.child1/pausedobj147",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5736,7 +5736,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj151",
+                      "actor": "server2.conn38.child1/pausedobj148",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5759,7 +5759,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj152",
+                      "actor": "server2.conn38.child1/pausedobj149",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5783,7 +5783,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj153",
+                      "actor": "server2.conn38.child1/pausedobj150",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5798,7 +5798,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj154",
+                      "actor": "server2.conn38.child1/pausedobj151",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5813,7 +5813,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj155",
+                      "actor": "server2.conn38.child1/pausedobj152",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5828,7 +5828,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj156",
+                      "actor": "server2.conn38.child1/pausedobj153",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5843,7 +5843,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj157",
+                      "actor": "server2.conn38.child1/pausedobj154",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5858,7 +5858,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj158",
+                      "actor": "server2.conn38.child1/pausedobj155",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5873,7 +5873,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj159",
+                      "actor": "server2.conn38.child1/pausedobj156",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5888,7 +5888,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj160",
+                      "actor": "server2.conn38.child1/pausedobj157",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5903,7 +5903,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj161",
+                      "actor": "server2.conn38.child1/pausedobj158",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5918,7 +5918,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj162",
+                      "actor": "server2.conn38.child1/pausedobj159",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -5933,7 +5933,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj163",
+                              "actor": "server2.conn38.child1/pausedobj160",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -5951,7 +5951,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj164",
+                              "actor": "server2.conn38.child1/pausedobj161",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -5969,7 +5969,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj165",
+                              "actor": "server2.conn38.child1/pausedobj162",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -5987,7 +5987,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj166",
+                              "actor": "server2.conn38.child1/pausedobj163",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -6005,7 +6005,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj167",
+                              "actor": "server2.conn38.child1/pausedobj164",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -6023,7 +6023,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj168",
+                              "actor": "server2.conn38.child1/pausedobj165",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -6041,7 +6041,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj163",
+                              "actor": "server2.conn38.child1/pausedobj160",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -6059,7 +6059,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj164",
+                              "actor": "server2.conn38.child1/pausedobj161",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -6077,7 +6077,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj164",
+                              "actor": "server2.conn38.child1/pausedobj161",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -6095,7 +6095,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj164",
+                              "actor": "server2.conn38.child1/pausedobj161",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -6118,7 +6118,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj169",
+                      "actor": "server2.conn38.child1/pausedobj166",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6141,7 +6141,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj170",
+                      "actor": "server2.conn38.child1/pausedobj167",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6163,7 +6163,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj171",
+                      "actor": "server2.conn38.child1/pausedobj168",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6185,7 +6185,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj172",
+                      "actor": "server2.conn38.child1/pausedobj169",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6208,7 +6208,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj173",
+                      "actor": "server2.conn38.child1/pausedobj170",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6231,7 +6231,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj174",
+                      "actor": "server2.conn38.child1/pausedobj171",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6254,7 +6254,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj175",
+                      "actor": "server2.conn38.child1/pausedobj172",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6277,7 +6277,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj176",
+                      "actor": "server2.conn38.child1/pausedobj173",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6308,7 +6308,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj177",
+                      "actor": "server2.conn38.child1/pausedobj174",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6323,7 +6323,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj178",
+                      "actor": "server2.conn38.child1/pausedobj175",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6338,7 +6338,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj179",
+                      "actor": "server2.conn38.child1/pausedobj176",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6353,7 +6353,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj180",
+                      "actor": "server2.conn38.child1/pausedobj177",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6368,7 +6368,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj181",
+                      "actor": "server2.conn38.child1/pausedobj178",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6383,7 +6383,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj182",
+                      "actor": "server2.conn38.child1/pausedobj179",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6410,7 +6410,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj183",
+                      "actor": "server2.conn38.child1/pausedobj180",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6449,7 +6449,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj184",
+                      "actor": "server2.conn38.child1/pausedobj181",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6482,7 +6482,7 @@
                     "value": {
                       "type": "object",
                       "class": "Array",
-                      "actor": "server2.conn120.pausedobj185",
+                      "actor": "server2.conn38.child1/pausedobj182",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6506,7 +6506,7 @@
                     "value": {
                       "type": "object",
                       "class": "Array",
-                      "actor": "server2.conn120.pausedobj186",
+                      "actor": "server2.conn38.child1/pausedobj183",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6530,7 +6530,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj187",
+                      "actor": "server2.conn38.child1/pausedobj184",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6553,7 +6553,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj188",
+                      "actor": "server2.conn38.child1/pausedobj185",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6576,7 +6576,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj189",
+                      "actor": "server2.conn38.child1/pausedobj186",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6598,7 +6598,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj190",
+                      "actor": "server2.conn38.child1/pausedobj187",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6621,7 +6621,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj191",
+                      "actor": "server2.conn38.child1/pausedobj188",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6645,7 +6645,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj192",
+                      "actor": "server2.conn38.child1/pausedobj189",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6671,7 +6671,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj193",
+                      "actor": "server2.conn38.child1/pausedobj190",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6695,7 +6695,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj194",
+                      "actor": "server2.conn38.child1/pausedobj191",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6717,7 +6717,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj195",
+                      "actor": "server2.conn38.child1/pausedobj192",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6740,7 +6740,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj196",
+                      "actor": "server2.conn38.child1/pausedobj193",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6755,7 +6755,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj197",
+                      "actor": "server2.conn38.child1/pausedobj194",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6770,7 +6770,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj198",
+                      "actor": "server2.conn38.child1/pausedobj195",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6785,7 +6785,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj199",
+                      "actor": "server2.conn38.child1/pausedobj196",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6800,7 +6800,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj200",
+                      "actor": "server2.conn38.child1/pausedobj197",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6815,7 +6815,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj201",
+                      "actor": "server2.conn38.child1/pausedobj198",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6840,7 +6840,7 @@
                     "value": {
                       "type": "object",
                       "class": "Array",
-                      "actor": "server2.conn120.pausedobj202",
+                      "actor": "server2.conn38.child1/pausedobj199",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6867,7 +6867,7 @@
                   "ajax_nonce": {
                     "enumerable": true,
                     "configurable": false,
-                    "value": 1466546398350,
+                    "value": 1467818191372,
                     "writable": true
                   },
                   "ajax_rquery": {
@@ -6876,7 +6876,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj203",
+                      "actor": "server2.conn38.child1/pausedobj200",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6891,7 +6891,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj204",
+                      "actor": "server2.conn38.child1/pausedobj201",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6906,7 +6906,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj205",
+                      "actor": "server2.conn38.child1/pausedobj202",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6921,7 +6921,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj206",
+                      "actor": "server2.conn38.child1/pausedobj203",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6936,7 +6936,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj207",
+                      "actor": "server2.conn38.child1/pausedobj204",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6951,7 +6951,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj208",
+                      "actor": "server2.conn38.child1/pausedobj205",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6966,7 +6966,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj209",
+                      "actor": "server2.conn38.child1/pausedobj206",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -6981,7 +6981,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj210",
+                      "actor": "server2.conn38.child1/pausedobj207",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7003,7 +7003,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj211",
+                      "actor": "server2.conn38.child1/pausedobj208",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7018,7 +7018,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj212",
+                              "actor": "server2.conn38.child1/pausedobj209",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -7036,7 +7036,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj213",
+                              "actor": "server2.conn38.child1/pausedobj210",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -7054,7 +7054,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj214",
+                              "actor": "server2.conn38.child1/pausedobj211",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -7078,7 +7078,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj215",
+                      "actor": "server2.conn38.child1/pausedobj212",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7093,7 +7093,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj216",
+                              "actor": "server2.conn38.child1/pausedobj213",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -7111,7 +7111,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj217",
+                              "actor": "server2.conn38.child1/pausedobj214",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -7141,7 +7141,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj218",
+                      "actor": "server2.conn38.child1/pausedobj215",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7166,7 +7166,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj219",
+                      "actor": "server2.conn38.child1/pausedobj216",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7189,7 +7189,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj220",
+                      "actor": "server2.conn38.child1/pausedobj217",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7213,7 +7213,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj221",
+                      "actor": "server2.conn38.child1/pausedobj218",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7238,7 +7238,7 @@
                     "value": {
                       "type": "object",
                       "class": "Array",
-                      "actor": "server2.conn120.pausedobj222",
+                      "actor": "server2.conn38.child1/pausedobj219",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7257,7 +7257,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj223",
+                      "actor": "server2.conn38.child1/pausedobj220",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7278,7 +7278,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj224",
+                      "actor": "server2.conn38.child1/pausedobj221",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7317,7 +7317,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj225",
+                      "actor": "server2.conn38.child1/pausedobj222",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7353,7 +7353,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj226",
+                      "actor": "server2.conn38.child1/pausedobj223",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7368,7 +7368,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj227",
+                      "actor": "server2.conn38.child1/pausedobj224",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7383,7 +7383,7 @@
                     "value": {
                       "type": "object",
                       "class": "RegExp",
-                      "actor": "server2.conn120.pausedobj228",
+                      "actor": "server2.conn38.child1/pausedobj225",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7398,7 +7398,7 @@
                     "value": {
                       "type": "object",
                       "class": "Array",
-                      "actor": "server2.conn120.pausedobj229",
+                      "actor": "server2.conn38.child1/pausedobj226",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7410,7 +7410,7 @@
                           {
                             "type": "object",
                             "class": "Function",
-                            "actor": "server2.conn120.pausedobj230",
+                            "actor": "server2.conn38.child1/pausedobj227",
                             "extensible": true,
                             "frozen": false,
                             "sealed": false,
@@ -7437,7 +7437,7 @@
                     "value": {
                       "type": "object",
                       "class": "Object",
-                      "actor": "server2.conn120.pausedobj231",
+                      "actor": "server2.conn38.child1/pausedobj228",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7452,7 +7452,7 @@
                             "value": {
                               "type": "object",
                               "class": "Array",
-                              "actor": "server2.conn120.pausedobj232",
+                              "actor": "server2.conn38.child1/pausedobj229",
                               "extensible": true,
                               "frozen": false,
                               "sealed": false,
@@ -7476,7 +7476,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj233",
+                      "actor": "server2.conn38.child1/pausedobj230",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7496,7 +7496,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj234",
+                      "actor": "server2.conn38.child1/pausedobj231",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7520,7 +7520,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj235",
+                      "actor": "server2.conn38.child1/pausedobj232",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7544,7 +7544,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj236",
+                      "actor": "server2.conn38.child1/pausedobj233",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7567,7 +7567,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj237",
+                      "actor": "server2.conn38.child1/pausedobj234",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7593,7 +7593,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj238",
+                      "actor": "server2.conn38.child1/pausedobj235",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7616,7 +7616,7 @@
                     "value": {
                       "type": "object",
                       "class": "Function",
-                      "actor": "server2.conn120.pausedobj239",
+                      "actor": "server2.conn38.child1/pausedobj236",
                       "extensible": true,
                       "frozen": false,
                       "sealed": false,
@@ -7701,7 +7701,7 @@
             "function": {
               "type": "object",
               "class": "Function",
-              "actor": "server2.conn120.pausedobj258",
+              "actor": "server2.conn38.child1/pausedobj255",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -7792,7 +7792,7 @@
                   "value": {
                     "type": "object",
                     "class": "Function",
-                    "actor": "server2.conn120.pausedobj259",
+                    "actor": "server2.conn38.child1/pausedobj256",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -7912,7 +7912,7 @@
           "function": {
             "type": "object",
             "class": "Function",
-            "actor": "server2.conn120.pausedobj259",
+            "actor": "server2.conn38.child1/pausedobj256",
             "extensible": true,
             "frozen": false,
             "sealed": false,
@@ -7934,7 +7934,7 @@
                   "value": {
                     "type": "object",
                     "class": "Event",
-                    "actor": "server2.conn120.pausedobj260",
+                    "actor": "server2.conn38.child1/pausedobj257",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -7947,7 +7947,7 @@
                         "currentTarget": {
                           "type": "object",
                           "class": "HTMLLIElement",
-                          "actor": "server2.conn120.pausedobj80",
+                          "actor": "server2.conn38.child1/pausedobj77",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -7966,11 +7966,11 @@
                         "bubbles": true,
                         "cancelable": false,
                         "defaultPrevented": false,
-                        "timeStamp": 1466546401646235,
+                        "timeStamp": 1467818195619794,
                         "originalTarget": {
                           "type": "object",
                           "class": "HTMLInputElement",
-                          "actor": "server2.conn120.pausedobj243",
+                          "actor": "server2.conn38.child1/pausedobj240",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -7980,8 +7980,8 @@
                             "nodeType": 1,
                             "nodeName": "input",
                             "attributes": {
-                              "value": "dtheretheretheretherethere",
-                              "class": "edit"
+                              "class": "edit",
+                              "value": "hitherethere"
                             },
                             "attributesLength": 2
                           }
@@ -7989,7 +7989,7 @@
                         "explicitOriginalTarget": {
                           "type": "object",
                           "class": "HTMLInputElement",
-                          "actor": "server2.conn120.pausedobj243",
+                          "actor": "server2.conn38.child1/pausedobj240",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -7999,8 +7999,8 @@
                             "nodeType": 1,
                             "nodeName": "input",
                             "attributes": {
-                              "value": "dtheretheretheretherethere",
-                              "class": "edit"
+                              "class": "edit",
+                              "value": "hitherethere"
                             },
                             "attributesLength": 2
                           }
@@ -8010,7 +8010,7 @@
                       "target": {
                         "type": "object",
                         "class": "HTMLInputElement",
-                        "actor": "server2.conn120.pausedobj243",
+                        "actor": "server2.conn38.child1/pausedobj240",
                         "extensible": true,
                         "frozen": false,
                         "sealed": false,
@@ -8020,8 +8020,8 @@
                           "nodeType": 1,
                           "nodeName": "input",
                           "attributes": {
-                            "value": "dtheretheretheretherethere",
-                            "class": "edit"
+                            "class": "edit",
+                            "value": "hitherethere"
                           },
                           "attributesLength": 2
                         }
@@ -8039,7 +8039,7 @@
                 "value": {
                   "type": "object",
                   "class": "Arguments",
-                  "actor": "server2.conn120.pausedobj261",
+                  "actor": "server2.conn38.child1/pausedobj258",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -8056,36 +8056,867 @@
             }
           }
         }
-      }
-    ],
-    "selectedFrame": {
-      "id": "server2.conn120.64",
-      "displayName": "app.TodoView<.updateOnEnter",
-      "location": {
-        "sourceId": "server2.conn120.source42",
-        "line": 113,
-        "column": 17
       },
-      "scope": {
-        "actor": "server2.conn120.environment66",
-        "type": "function",
-        "parent": {
-          "actor": "server2.conn120.environment67",
+      {
+        "id": "server2.conn38.child1/259",
+        "displayName": "sendKey",
+        "location": {
+          "sourceId": "server2.conn38.child1/54",
+          "line": 68,
+          "column": 5
+        },
+        "scope": {
+          "actor": "server2.conn38.child1/261",
           "type": "function",
           "parent": {
-            "actor": "server2.conn120.environment68",
+            "actor": "server2.conn38.child1/262",
+            "type": "function",
+            "parent": {
+              "actor": "server2.conn38.child1/263",
+              "type": "block",
+              "parent": {
+                "actor": "server2.conn38.child1/264",
+                "type": "with",
+                "parent": {
+                  "actor": "server2.conn38.child1/65",
+                  "type": "block",
+                  "parent": {
+                    "actor": "server2.conn38.child1/66",
+                    "type": "object",
+                    "object": {
+                      "type": "object",
+                      "class": "Window",
+                      "actor": "server2.conn38.child1/pausedobj67",
+                      "extensible": true,
+                      "frozen": false,
+                      "sealed": false,
+                      "ownPropertyLength": 783,
+                      "preview": {
+                        "kind": "ObjectWithURL",
+                        "url": "http://localhost:8000/todomvc/"
+                      }
+                    }
+                  },
+                  "bindings": {
+                    "arguments": [],
+                    "variables": {}
+                  }
+                },
+                "object": {
+                  "type": "object",
+                  "class": "Object",
+                  "actor": "server2.conn38.child1/pausedobj265",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 14,
+                  "preview": {
+                    "kind": "Object",
+                    "ownProperties": {},
+                    "ownPropertiesLength": 14,
+                    "safeGetterValues": {}
+                  }
+                }
+              },
+              "bindings": {
+                "arguments": [],
+                "variables": {
+                  "Debuggee": {
+                    "enumerable": true,
+                    "configurable": false,
+                    "value": {
+                      "type": "object",
+                      "class": "Function",
+                      "actor": "server2.conn38.child1/pausedobj266",
+                      "extensible": true,
+                      "frozen": false,
+                      "sealed": false,
+                      "name": "Debuggee",
+                      "displayName": "Debuggee",
+                      "parameterNames": [],
+                      "location": {
+                        "url": "debugger eval code",
+                        "line": 1
+                      }
+                    },
+                    "writable": true
+                  }
+                }
+              }
+            },
+            "function": {
+              "type": "object",
+              "class": "Function",
+              "actor": "server2.conn38.child1/pausedobj266",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "name": "Debuggee",
+              "displayName": "Debuggee",
+              "parameterNames": [],
+              "location": {
+                "url": "debugger eval code",
+                "line": 1
+              }
+            },
+            "bindings": {
+              "arguments": [],
+              "variables": {
+                "arguments": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "null",
+                    "missingArguments": true
+                  },
+                  "writable": false
+                },
+                "$": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn38.child1/pausedobj267",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "$",
+                    "displayName": "$",
+                    "parameterNames": [
+                      "selector"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 2
+                    }
+                  },
+                  "writable": true
+                },
+                "mouseEvent": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn38.child1/pausedobj268",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "mouseEvent",
+                    "displayName": "mouseEvent",
+                    "parameterNames": [
+                      "eventType"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 12
+                    }
+                  },
+                  "writable": true
+                },
+                "isSpecialCharacter": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn38.child1/pausedobj269",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "isSpecialCharacter",
+                    "displayName": "isSpecialCharacter",
+                    "parameterNames": [
+                      "text"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 25
+                    }
+                  },
+                  "writable": true
+                },
+                "keyInfo": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn38.child1/pausedobj270",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "keyInfo",
+                    "displayName": "keyInfo",
+                    "parameterNames": [
+                      "key",
+                      "eventType"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 29
+                    }
+                  },
+                  "writable": true
+                },
+                "keyEvent": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn38.child1/pausedobj271",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "keyEvent",
+                    "displayName": "keyEvent",
+                    "parameterNames": [
+                      "eventType",
+                      "key"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 45
+                    }
+                  },
+                  "writable": true
+                },
+                "sendKey": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn38.child1/pausedobj272",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "sendKey",
+                    "displayName": "sendKey",
+                    "parameterNames": [
+                      "element",
+                      "key"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 66
+                    }
+                  },
+                  "writable": true
+                },
+                "specialKeysMap": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Object",
+                    "actor": "server2.conn38.child1/pausedobj273",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "ownPropertyLength": 1,
+                    "preview": {
+                      "kind": "Object",
+                      "ownProperties": {
+                        "{enter}": {
+                          "configurable": true,
+                          "enumerable": true,
+                          "writable": true,
+                          "value": 13
+                        }
+                      },
+                      "ownPropertiesLength": 1,
+                      "safeGetterValues": {}
+                    }
+                  },
+                  "writable": true
+                },
+                "click": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "null",
+                    "optimizedOut": true
+                  },
+                  "writable": false
+                },
+                "dblclick": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "null",
+                    "optimizedOut": true
+                  },
+                  "writable": false
+                },
+                "type": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "null",
+                    "optimizedOut": true
+                  },
+                  "writable": false
+                }
+              }
+            }
+          },
+          "function": {
+            "type": "object",
+            "class": "Function",
+            "actor": "server2.conn38.child1/pausedobj272",
+            "extensible": true,
+            "frozen": false,
+            "sealed": false,
+            "name": "sendKey",
+            "displayName": "sendKey",
+            "parameterNames": [
+              "element",
+              "key"
+            ],
+            "location": {
+              "url": "debugger eval code",
+              "line": 66
+            }
+          },
+          "bindings": {
+            "arguments": [
+              {
+                "element": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "HTMLInputElement",
+                    "actor": "server2.conn38.child1/pausedobj274",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "ownPropertyLength": 0,
+                    "preview": {
+                      "kind": "DOMNode",
+                      "nodeType": 1,
+                      "nodeName": "input",
+                      "attributes": {
+                        "class": "edit",
+                        "value": "hitherethere"
+                      },
+                      "attributesLength": 2
+                    }
+                  },
+                  "writable": true
+                }
+              },
+              {
+                "key": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": "{enter}",
+                  "writable": true
+                }
+              }
+            ],
+            "variables": {
+              "arguments": {
+                "enumerable": true,
+                "configurable": false,
+                "value": {
+                  "type": "object",
+                  "class": "Arguments",
+                  "actor": "server2.conn38.child1/pausedobj275",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 4,
+                  "preview": {
+                    "kind": "Object",
+                    "ownProperties": {},
+                    "ownPropertiesLength": 4,
+                    "safeGetterValues": {}
+                  }
+                },
+                "writable": true
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "server2.conn38.child1/277",
+        "displayName": "type",
+        "location": {
+          "sourceId": "server2.conn38.child1/54",
+          "line": 93,
+          "column": 7
+        },
+        "scope": {
+          "actor": "server2.conn38.child1/279",
+          "type": "function",
+          "parent": {
+            "actor": "server2.conn38.child1/262",
+            "type": "function",
+            "parent": {
+              "actor": "server2.conn38.child1/263",
+              "type": "block",
+              "parent": {
+                "actor": "server2.conn38.child1/264",
+                "type": "with",
+                "parent": {
+                  "actor": "server2.conn38.child1/65",
+                  "type": "block",
+                  "parent": {
+                    "actor": "server2.conn38.child1/66",
+                    "type": "object",
+                    "object": {
+                      "type": "object",
+                      "class": "Window",
+                      "actor": "server2.conn38.child1/pausedobj67",
+                      "extensible": true,
+                      "frozen": false,
+                      "sealed": false,
+                      "ownPropertyLength": 783,
+                      "preview": {
+                        "kind": "ObjectWithURL",
+                        "url": "http://localhost:8000/todomvc/"
+                      }
+                    }
+                  },
+                  "bindings": {
+                    "arguments": [],
+                    "variables": {}
+                  }
+                },
+                "object": {
+                  "type": "object",
+                  "class": "Object",
+                  "actor": "server2.conn38.child1/pausedobj265",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 14,
+                  "preview": {
+                    "kind": "Object",
+                    "ownProperties": {},
+                    "ownPropertiesLength": 14,
+                    "safeGetterValues": {}
+                  }
+                }
+              },
+              "bindings": {
+                "arguments": [],
+                "variables": {
+                  "Debuggee": {
+                    "enumerable": true,
+                    "configurable": false,
+                    "value": {
+                      "type": "object",
+                      "class": "Function",
+                      "actor": "server2.conn38.child1/pausedobj266",
+                      "extensible": true,
+                      "frozen": false,
+                      "sealed": false,
+                      "name": "Debuggee",
+                      "displayName": "Debuggee",
+                      "parameterNames": [],
+                      "location": {
+                        "url": "debugger eval code",
+                        "line": 1
+                      }
+                    },
+                    "writable": true
+                  }
+                }
+              }
+            },
+            "function": {
+              "type": "object",
+              "class": "Function",
+              "actor": "server2.conn38.child1/pausedobj266",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "name": "Debuggee",
+              "displayName": "Debuggee",
+              "parameterNames": [],
+              "location": {
+                "url": "debugger eval code",
+                "line": 1
+              }
+            },
+            "bindings": {
+              "arguments": [],
+              "variables": {
+                "arguments": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "null",
+                    "missingArguments": true
+                  },
+                  "writable": false
+                },
+                "$": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn38.child1/pausedobj267",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "$",
+                    "displayName": "$",
+                    "parameterNames": [
+                      "selector"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 2
+                    }
+                  },
+                  "writable": true
+                },
+                "mouseEvent": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn38.child1/pausedobj268",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "mouseEvent",
+                    "displayName": "mouseEvent",
+                    "parameterNames": [
+                      "eventType"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 12
+                    }
+                  },
+                  "writable": true
+                },
+                "isSpecialCharacter": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn38.child1/pausedobj269",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "isSpecialCharacter",
+                    "displayName": "isSpecialCharacter",
+                    "parameterNames": [
+                      "text"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 25
+                    }
+                  },
+                  "writable": true
+                },
+                "keyInfo": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn38.child1/pausedobj270",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "keyInfo",
+                    "displayName": "keyInfo",
+                    "parameterNames": [
+                      "key",
+                      "eventType"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 29
+                    }
+                  },
+                  "writable": true
+                },
+                "keyEvent": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn38.child1/pausedobj271",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "keyEvent",
+                    "displayName": "keyEvent",
+                    "parameterNames": [
+                      "eventType",
+                      "key"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 45
+                    }
+                  },
+                  "writable": true
+                },
+                "sendKey": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Function",
+                    "actor": "server2.conn38.child1/pausedobj272",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "name": "sendKey",
+                    "displayName": "sendKey",
+                    "parameterNames": [
+                      "element",
+                      "key"
+                    ],
+                    "location": {
+                      "url": "debugger eval code",
+                      "line": 66
+                    }
+                  },
+                  "writable": true
+                },
+                "specialKeysMap": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "object",
+                    "class": "Object",
+                    "actor": "server2.conn38.child1/pausedobj273",
+                    "extensible": true,
+                    "frozen": false,
+                    "sealed": false,
+                    "ownPropertyLength": 1,
+                    "preview": {
+                      "kind": "Object",
+                      "ownProperties": {
+                        "{enter}": {
+                          "configurable": true,
+                          "enumerable": true,
+                          "writable": true,
+                          "value": 13
+                        }
+                      },
+                      "ownPropertiesLength": 1,
+                      "safeGetterValues": {}
+                    }
+                  },
+                  "writable": true
+                },
+                "click": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "null",
+                    "optimizedOut": true
+                  },
+                  "writable": false
+                },
+                "dblclick": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "null",
+                    "optimizedOut": true
+                  },
+                  "writable": false
+                },
+                "type": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": {
+                    "type": "null",
+                    "optimizedOut": true
+                  },
+                  "writable": false
+                }
+              }
+            }
+          },
+          "function": {
+            "type": "object",
+            "class": "Function",
+            "actor": "server2.conn38.child1/pausedobj280",
+            "extensible": true,
+            "frozen": false,
+            "sealed": false,
+            "name": "type",
+            "displayName": "type",
+            "parameterNames": [
+              "selector",
+              "text"
+            ],
+            "location": {
+              "url": "debugger eval code",
+              "line": 87
+            }
+          },
+          "bindings": {
+            "arguments": [
+              {
+                "selector": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": "#todo-list li .edit",
+                  "writable": true
+                }
+              },
+              {
+                "text": {
+                  "enumerable": true,
+                  "configurable": false,
+                  "value": "{enter}",
+                  "writable": true
+                }
+              }
+            ],
+            "variables": {
+              "arguments": {
+                "enumerable": true,
+                "configurable": false,
+                "value": {
+                  "type": "object",
+                  "class": "Arguments",
+                  "actor": "server2.conn38.child1/pausedobj281",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 4,
+                  "preview": {
+                    "kind": "Object",
+                    "ownProperties": {},
+                    "ownPropertiesLength": 4,
+                    "safeGetterValues": {}
+                  }
+                },
+                "writable": true
+              },
+              "element": {
+                "enumerable": true,
+                "configurable": false,
+                "value": {
+                  "type": "object",
+                  "class": "HTMLInputElement",
+                  "actor": "server2.conn38.child1/pausedobj282",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 0,
+                  "preview": {
+                    "kind": "DOMNode",
+                    "nodeType": 1,
+                    "nodeName": "input",
+                    "attributes": {
+                      "class": "edit",
+                      "value": "hitherethere"
+                    },
+                    "attributesLength": 2
+                  }
+                },
+                "writable": true
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "server2.conn38.child1/286",
+        "displayName": "(global)",
+        "location": {
+          "sourceId": "server2.conn38.child1/59",
+          "line": 3,
+          "column": 4
+        },
+        "scope": {
+          "actor": "server2.conn38.child1/287",
+          "type": "with",
+          "parent": {
+            "actor": "server2.conn38.child1/65",
             "type": "block",
             "parent": {
-              "actor": "server2.conn120.environment69",
+              "actor": "server2.conn38.child1/66",
               "type": "object",
               "object": {
                 "type": "object",
                 "class": "Window",
-                "actor": "server2.conn120.pausedobj70",
+                "actor": "server2.conn38.child1/pausedobj67",
                 "extensible": true,
                 "frozen": false,
                 "sealed": false,
-                "ownPropertyLength": 734,
+                "ownPropertyLength": 783,
+                "preview": {
+                  "kind": "ObjectWithURL",
+                  "url": "http://localhost:8000/todomvc/"
+                }
+              }
+            },
+            "bindings": {
+              "arguments": [],
+              "variables": {}
+            }
+          },
+          "object": {
+            "type": "object",
+            "class": "Object",
+            "actor": "server2.conn38.child1/pausedobj288",
+            "extensible": true,
+            "frozen": false,
+            "sealed": false,
+            "ownPropertyLength": 14,
+            "preview": {
+              "kind": "Object",
+              "ownProperties": {},
+              "ownPropertiesLength": 14,
+              "safeGetterValues": {}
+            }
+          }
+        }
+      }
+    ],
+    "selectedFrame": {
+      "id": "server2.conn38.child1/61",
+      "displayName": "app.TodoView<.updateOnEnter",
+      "location": {
+        "sourceId": "server2.conn38.child1/36",
+        "line": 113,
+        "column": 4
+      },
+      "scope": {
+        "actor": "server2.conn38.child1/63",
+        "type": "function",
+        "parent": {
+          "actor": "server2.conn38.child1/64",
+          "type": "function",
+          "parent": {
+            "actor": "server2.conn38.child1/65",
+            "type": "block",
+            "parent": {
+              "actor": "server2.conn38.child1/66",
+              "type": "object",
+              "object": {
+                "type": "object",
+                "class": "Window",
+                "actor": "server2.conn38.child1/pausedobj67",
+                "extensible": true,
+                "frozen": false,
+                "sealed": false,
+                "ownPropertyLength": 783,
                 "preview": {
                   "kind": "ObjectWithURL",
                   "url": "http://localhost:8000/todomvc/"
@@ -8100,7 +8931,7 @@
           "function": {
             "type": "object",
             "class": "Function",
-            "actor": "server2.conn120.pausedobj71",
+            "actor": "server2.conn38.child1/pausedobj68",
             "extensible": true,
             "frozen": false,
             "sealed": false,
@@ -8142,7 +8973,7 @@
         "function": {
           "type": "object",
           "class": "Function",
-          "actor": "server2.conn120.pausedobj72",
+          "actor": "server2.conn38.child1/pausedobj69",
           "extensible": true,
           "frozen": false,
           "sealed": false,
@@ -8164,7 +8995,7 @@
                 "value": {
                   "type": "object",
                   "class": "Object",
-                  "actor": "server2.conn120.pausedobj73",
+                  "actor": "server2.conn38.child1/pausedobj70",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -8179,7 +9010,7 @@
                         "value": {
                           "type": "object",
                           "class": "Event",
-                          "actor": "server2.conn120.pausedobj74",
+                          "actor": "server2.conn38.child1/pausedobj71",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -8193,7 +9024,7 @@
                               "bubbles": true,
                               "cancelable": false,
                               "defaultPrevented": false,
-                              "timeStamp": 1466546401646235,
+                              "timeStamp": 1467818195619794,
                               "NONE": 0,
                               "CAPTURING_PHASE": 1,
                               "AT_TARGET": 2,
@@ -8215,7 +9046,7 @@
                         "value": {
                           "type": "object",
                           "class": "Function",
-                          "actor": "server2.conn120.pausedobj75",
+                          "actor": "server2.conn38.child1/pausedobj72",
                           "extensible": true,
                           "frozen": false,
                           "sealed": false,
@@ -8232,9 +9063,9 @@
                         "configurable": true,
                         "enumerable": true,
                         "writable": true,
-                        "value": 1466546401646235
+                        "value": 1467818195619794
                       },
-                      "jQuery2030059558816119138824": {
+                      "jQuery2030924186586612804": {
                         "configurable": true,
                         "enumerable": true,
                         "writable": true,
@@ -8244,7 +9075,7 @@
                         "configurable": true,
                         "enumerable": true,
                         "writable": true,
-                        "value": 84
+                        "value": 13
                       },
                       "key": {
                         "configurable": true,
@@ -8272,7 +9103,7 @@
                         "configurable": true,
                         "enumerable": true,
                         "writable": true,
-                        "value": 84
+                        "value": 13
                       }
                     },
                     "ownPropertiesLength": 24
@@ -8289,7 +9120,7 @@
               "value": {
                 "type": "object",
                 "class": "Arguments",
-                "actor": "server2.conn120.pausedobj76",
+                "actor": "server2.conn38.child1/pausedobj73",
                 "extensible": true,
                 "frozen": false,
                 "sealed": false,
@@ -8308,7 +9139,7 @@
       }
     },
     "loadedObjects": {
-      "server2.conn120.pausedobj73": [
+      "server2.conn38.child1/pausedobj70": [
         [
           "altKey",
           {
@@ -8378,7 +9209,7 @@
             "value": {
               "type": "object",
               "class": "HTMLInputElement",
-              "actor": "server2.conn120.pausedobj243",
+              "actor": "server2.conn38.child1/pausedobj240",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -8388,8 +9219,8 @@
                 "nodeType": 1,
                 "nodeName": "input",
                 "attributes": {
-                  "value": "dtheretheretheretherethere",
-                  "class": "edit"
+                  "class": "edit",
+                  "value": "hitherethere"
                 },
                 "attributesLength": 2
               }
@@ -8416,7 +9247,7 @@
             "value": {
               "type": "object",
               "class": "HTMLLIElement",
-              "actor": "server2.conn120.pausedobj80",
+              "actor": "server2.conn38.child1/pausedobj77",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -8451,7 +9282,7 @@
             "value": {
               "type": "object",
               "class": "Object",
-              "actor": "server2.conn120.pausedobj251",
+              "actor": "server2.conn38.child1/pausedobj248",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -8484,11 +9315,13 @@
                     "enumerable": true,
                     "writable": true,
                     "value": {
-                      "type": "object",
-                      "class": "Function",
-                      "actor": "server2.conn120.pausedobj246",
-                      "extensible": true,
                       "frozen": false,
+                      "name": "bound updateOnEnter",
+                      "displayName": "bound updateOnEnter",
+                      "actor": "server2.conn38.child1/pausedobj243",
+                      "class": "Function",
+                      "type": "object",
+                      "extensible": true,
                       "sealed": false,
                       "parameterNames": []
                     }
@@ -8515,7 +9348,7 @@
                     "configurable": true,
                     "enumerable": true,
                     "writable": true,
-                    "value": "delegateEventsview28"
+                    "value": "delegateEventsview10"
                   }
                 },
                 "ownPropertiesLength": 8,
@@ -8534,7 +9367,7 @@
               "frozen": false,
               "name": "returnFalse",
               "displayName": "returnFalse",
-              "actor": "server2.conn120.pausedobj75",
+              "actor": "server2.conn38.child1/pausedobj72",
               "location": {
                 "url": "http://localhost:8000/todomvc/bower_components/jquery/jquery.js",
                 "line": 4309
@@ -8548,7 +9381,7 @@
           }
         ],
         [
-          "jQuery2030059558816119138824",
+          "jQuery2030924186586612804",
           {
             "configurable": true,
             "enumerable": true,
@@ -8573,7 +9406,7 @@
             "configurable": true,
             "enumerable": true,
             "writable": true,
-            "value": 84
+            "value": 13
           }
         ],
         [
@@ -8596,7 +9429,7 @@
             "value": {
               "type": "object",
               "class": "Event",
-              "actor": "server2.conn120.pausedobj74",
+              "actor": "server2.conn38.child1/pausedobj71",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -8609,7 +9442,7 @@
                   "originalTarget": {
                     "type": "object",
                     "class": "HTMLInputElement",
-                    "actor": "server2.conn120.pausedobj243",
+                    "actor": "server2.conn38.child1/pausedobj240",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8619,8 +9452,8 @@
                       "nodeType": 1,
                       "nodeName": "input",
                       "attributes": {
-                        "value": "dtheretheretheretherethere",
-                        "class": "edit"
+                        "class": "edit",
+                        "value": "hitherethere"
                       },
                       "attributesLength": 2
                     }
@@ -8629,7 +9462,7 @@
                   "currentTarget": {
                     "type": "object",
                     "class": "HTMLLIElement",
-                    "actor": "server2.conn120.pausedobj80",
+                    "actor": "server2.conn38.child1/pausedobj77",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8646,11 +9479,11 @@
                   },
                   "isTrusted": false,
                   "cancelable": false,
-                  "timeStamp": 1466546401646235,
+                  "timeStamp": 1467818195619794,
                   "explicitOriginalTarget": {
                     "type": "object",
                     "class": "HTMLInputElement",
-                    "actor": "server2.conn120.pausedobj243",
+                    "actor": "server2.conn38.child1/pausedobj240",
                     "extensible": true,
                     "frozen": false,
                     "sealed": false,
@@ -8660,8 +9493,8 @@
                       "nodeType": 1,
                       "nodeName": "input",
                       "attributes": {
-                        "value": "dtheretheretheretherethere",
-                        "class": "edit"
+                        "class": "edit",
+                        "value": "hitherethere"
                       },
                       "attributesLength": 2
                     }
@@ -8672,7 +9505,7 @@
                 "target": {
                   "type": "object",
                   "class": "HTMLInputElement",
-                  "actor": "server2.conn120.pausedobj243",
+                  "actor": "server2.conn38.child1/pausedobj240",
                   "extensible": true,
                   "frozen": false,
                   "sealed": false,
@@ -8682,8 +9515,8 @@
                     "nodeType": 1,
                     "nodeName": "input",
                     "attributes": {
-                      "value": "dtheretheretheretherethere",
-                      "class": "edit"
+                      "class": "edit",
+                      "value": "hitherethere"
                     },
                     "attributesLength": 2
                   }
@@ -8723,7 +9556,7 @@
             "value": {
               "type": "object",
               "class": "HTMLInputElement",
-              "actor": "server2.conn120.pausedobj243",
+              "actor": "server2.conn38.child1/pausedobj240",
               "extensible": true,
               "frozen": false,
               "sealed": false,
@@ -8733,8 +9566,8 @@
                 "nodeType": 1,
                 "nodeName": "input",
                 "attributes": {
-                  "value": "dtheretheretheretherethere",
-                  "class": "edit"
+                  "class": "edit",
+                  "value": "hitherethere"
                 },
                 "attributesLength": 2
               }
@@ -8747,7 +9580,7 @@
             "configurable": true,
             "enumerable": true,
             "writable": true,
-            "value": 1466546401646235
+            "value": 1467818195619794
           }
         ],
         [
@@ -8776,7 +9609,7 @@
             "configurable": true,
             "enumerable": true,
             "writable": true,
-            "value": 84
+            "value": 13
           }
         ]
       ]

--- a/public/js/test/integration/fixtures.js
+++ b/public/js/test/integration/fixtures.js
@@ -20,6 +20,9 @@ xdescribe("Fixtures", function() {
     debugPage("todomvc");
     goToSource("js/views/todo-view");
     toggleBreakpoint(113);
+    toggleBreakpoint(119);
+    toggleBreakpoint(121);
+    toggleBreakpointInList(2); // toggle off the last breakpoint
     addTodo();
     editTodo();
     cy.wait(1000)


### PR DESCRIPTION
This creates style classes for breakpoints so I could make the font colour lighter to match the disabled state.  Needs @helenvholmes review.
I also added an option for the paused state so we could style that separately as well but couldn't find a style that I liked.  Maybe @helenvholmes has ideas for this or it can remain the same.  I used CSS animations to make the breakpoint "flash" a background color which worked pretty well but needs more thought into the timing because it distracted from the editor text location.

@jasonLaster I changed the storybook to be 3 breakpoints from 1 so I could have one of each type.  The last, disabled, breakpoint disappears when you check the box and I wasn't sure how to handle this.  I assuming it is the click handler running and then finding that breakpoint doesn't exist.  But I could use some help here.