### PR TITLE
greatly improve scope inspector, split out object inspector component and optimize it

### DIFF
--- a/public/js/components/ObjectInspector.js
+++ b/public/js/components/ObjectInspector.js
@@ -1,0 +1,167 @@
+"use strict";
+
+const React = require("react");
+const classnames = require("classnames");
+const ManagedTree = React.createFactory(require("./util/ManagedTree"));
+const Arrow = React.createFactory(require("./util/Arrow"));
+const Rep = require("./Rep");
+const { DOM: dom, PropTypes } = React;
+
+// This implements a component that renders an interactive inspector
+// for looking at JavaScript objects. It expects descriptions of
+// objects from the protocol, and will dynamically fetch child
+// properties as objects are expanded.
+//
+// If you want to inspect a single object, pass the name and the
+// protocol descriptor of it:
+//
+//  ObjectInspector({
+//    name: "foo",
+//    desc: { writable: true, ..., { value: { actor: "1", ... }}},
+//    ...
+//  })
+//
+// If you want multiple top-level objects (like scopes), you can pass
+// an array of manually constructed nodes as `roots`:
+//
+//  ObjectInspector({
+//    roots: [{ name: ... }, ...],
+//    ...
+//  });
+
+// There are 3 types of nodes: a simple node with a children array, an
+// object that has properties that should be children when they are
+// fetched, and a primitive value that should be displayed with no
+// children.
+
+function nodeHasChildren(item) {
+  return Array.isArray(item.contents);
+}
+
+function nodeHasProperties(item) {
+  return !nodeHasChildren(item) && item.contents.value.type === "object";
+}
+
+function nodeIsPrimitive(item) {
+  return !nodeHasChildren(item) && !nodeHasProperties(item);
+}
+
+function createNode(name, path, contents) {
+  // The path is important to uniquely identify the item in the entire
+  // tree. This helps debugging & optimizes React's rendering of large
+  // lists. The path will be separated by property name,
+  // i.e. `{ foo: { bar: { baz: 5 }}}` will have a path of `foo/bar/baz`
+  // for the inner object.
+  return { name, path, contents };
+}
+
+const ObjectInspector = React.createClass({
+  propTypes: {
+    name: PropTypes.string,
+    desc: PropTypes.object,
+    roots: PropTypes.array,
+    getObjectProperties: PropTypes.func.isRequired,
+    loadObjectProperties: PropTypes.func.isRequired
+  },
+
+  displayName: "ObjectInspector",
+
+  getInitialState() {
+    // Cache of dynamically built nodes. We shouldn't need to clear
+    // this out ever, since we don't ever "switch out" the object
+    // being inspected.
+    this.actorCache = {};
+    return {};
+  },
+
+  getChildren(item) {
+    const { getObjectProperties } = this.props;
+    const obj = item.contents;
+
+    // Nodes can either have children already, or be an object with
+    // properties that we need to go and fetch.
+    if (nodeHasChildren(item)) {
+      return item.contents;
+    } else if (nodeHasProperties(item)) {
+      const actor = obj.value.actor;
+
+      // Because we are dynamically creating the tree as the user
+      // expands it (not precalcuated tree structure), we cache child
+      // arrays. This not only helps performance, but is necessary
+      // because the expanded state depends on instances of nodes
+      // being the same across renders. If we didn't do this, each
+      // node would be a new instance every render.
+      if (this.actorCache[actor]) {
+        return this.actorCache[actor];
+      }
+
+      const loaded = getObjectProperties(actor);
+      if (loaded) {
+        this.actorCache[actor] = loaded.map(child => {
+          // This is where the path is constructed.
+          return createNode(child[0], item.path + "/" + child[0], child[1]);
+        });
+
+        return this.actorCache[actor];
+      }
+      return [];
+    }
+    return [];
+  },
+
+  renderItem(item, depth, focused, _, expanded, { setExpanded }) {
+    let objectValue;
+    if (nodeHasProperties(item) || nodeIsPrimitive(item)) {
+      const object = item.contents.value;
+      objectValue = Rep({ object });
+    }
+
+    return dom.div(
+      { className: classnames("node", { focused }),
+        style: { marginLeft: depth * 15 },
+        onClick: e => {
+          e.stopPropagation();
+          setExpanded(item, !expanded);
+        }
+      },
+      Arrow({
+        className: classnames({
+          expanded: expanded,
+          hidden: nodeIsPrimitive(item)
+        })
+      }),
+      dom.span({ className: "object-label" }, item.name),
+      dom.span({ className: "object-delimiter" },
+               objectValue ? ": " : ""),
+      dom.span({ className: "object-value" }, objectValue || "")
+    );
+  },
+
+  render() {
+    const { name, desc, loadObjectProperties } = this.props;
+
+    let roots = this.props.roots;
+    if (!roots) {
+      roots = [createNode(name, name, desc)];
+    }
+
+    return ManagedTree({
+      itemHeight: 20,
+      getParent: item => null,
+      getChildren: this.getChildren,
+      getRoots: () => roots,
+      getKey: item => item.path,
+      autoExpand: 0,
+      disabledFocus: true,
+      onExpand: item => {
+        if (nodeHasProperties(item)) {
+          loadObjectProperties(item.contents.value);
+        }
+      },
+
+      renderItem: this.renderItem
+    });
+  }
+});
+
+module.exports = ObjectInspector;

--- a/public/js/components/RightSidebar.js
+++ b/public/js/components/RightSidebar.js
@@ -26,7 +26,8 @@ function RightSidebar({ resume, command, breakOnNext,
                         pause, isWaitingOnBreak }) {
   return (
     dom.div(
-      { className: "right-sidebar" },
+      { className: "right-sidebar",
+        style: { overflow: "hidden" }},
       dom.div(
         { className: "command-bar" },
         pause ? [

--- a/public/js/components/Scopes.css
+++ b/public/js/components/Scopes.css
@@ -1,4 +1,23 @@
 
-.scope-object-label {
+.object-label {
   color: var(--theme-highlight-blue);
+}
+
+.objectBox-object,
+.objectBox-string,
+.objectBox-text,
+.objectBox-table,
+.objectLink-textNode,
+.objectLink-event,
+.objectLink-eventLog,
+.objectLink-regexp,
+.objectLink-object,
+.objectLink-Date,
+.theme-dark .objectBox-object,
+.theme-light .objectBox-object {
+  white-space: nowrap;
+}
+
+.scopes-list .tree-node {
+  overflow: hidden;
 }

--- a/public/js/components/util/ManagedTree.js
+++ b/public/js/components/util/ManagedTree.js
@@ -27,7 +27,7 @@ let ManagedTree = React.createClass({
   },
 
   focusItem(item) {
-    if (this.state.focusedItem !== item) {
+    if (!this.props.disabledFocus && this.state.focusedItem !== item) {
       this.setState({ focusedItem: item });
 
       if (this.props.onFocus) {

--- a/public/js/lib/devtools-sham/shared/DevToolsUtils.js
+++ b/public/js/lib/devtools-sham/shared/DevToolsUtils.js
@@ -81,15 +81,15 @@ exports.makeInfallible = function makeInfallible(aHandler, aName) {
     aName = aHandler.name;
 
   return function (/* arguments */) {
-    try {
+    // try {
       return aHandler.apply(this, arguments);
-    } catch (ex) {
-      let who = "Handler function";
-      if (aName) {
-        who += " " + aName;
-      }
-      return exports.reportException(who, ex);
-    }
+    // } catch (ex) {
+    //   let who = "Handler function";
+    //   if (aName) {
+    //     who += " " + aName;
+    //   }
+    //   return exports.reportException(who, ex);
+    // }
   }
 }
 

--- a/public/js/lib/tree.js
+++ b/public/js/lib/tree.js
@@ -60,6 +60,12 @@ const TreeNode = createFactory(createClass({
     }
   },
 
+  shouldComponentUpdate(nextProps) {
+    return this.props.item !== nextProps.item ||
+      this.props.focused !== nextProps.focused ||
+      this.props.expanded !== nextProps.expanded;
+  },
+
   render() {
     const arrow = ArrowExpander({
       item: this.props.item,

--- a/public/js/reducers/pause.js
+++ b/public/js/reducers/pause.js
@@ -45,14 +45,16 @@ function update(state = initialState, action, emit) {
 
     case constants.LOAD_OBJECT_PROPERTIES:
       if (action.status === "done") {
+        const props = action.value.ownProperties;
+
         return state.setIn(
           ["loadedObjects", action.objectId],
-          fromJS(action.value.ownProperties).entrySeq()
-            .filter(prop => {
-              return prop[0] !== "prototype" && prop[1].has("value");
+          Object.keys(props)
+            .filter(name => {
+              return name !== "prototype" && "value" in props[name];
             })
-            .sort((a, b) => a[0].localeCompare(b[0]))
-            .toArray()
+            .sort((a, b) => a.localeCompare(b))
+            .map(name => [name, props[name]])
         );
       }
       break;

--- a/public/js/util/sources-tree.js
+++ b/public/js/util/sources-tree.js
@@ -4,9 +4,7 @@ const URL = require("url");
 const { assert } = require("./DevToolsUtils");
 
 function nodeHasChildren(item) {
-  // Do not use `Array.isArray` because it's slower and we do not need
-  // to support multiple globals here.
-  return item.contents instanceof Array;
+  return Array.isArray(item.contents);
 }
 
 function createNode(name, path, contents) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,7 @@ if (isDevelopment()) {
 
     config.module.loaders.push({
       test: /\.js$/,
-      include: path.join(__dirname, "../public/js"),
+      include: path.join(__dirname, "./public/js"),
       loader: "react-hot"
     });
   }


### PR DESCRIPTION
This is a heavy refactoring of scopes that I've been wanting to do. There is now a standalone `ObjectInspector.js` component that will be easy to share. The only thing is that it depends on our tree stuff, and we've tweaked the tree from m-c and we have `ManagedTree`. But it shouldn't be hard to reconcile the tree component, and once that's done that component can be shared.

This greatly improves performance. If you have the window scope expanded with a million items, the tree is still fully interactive and you don't notice any slowdown.

Additionally, it's more accurate as to what values it shows. There are still things missing, and we should show things like functions better, but there's also much clearer places in the code to implement those kinds of things now.

<img width="401" alt="screen shot 2016-07-01 at 1 15 59 pm" src="https://cloud.githubusercontent.com/assets/17031/16529092/e987d210-3f8e-11e6-95c9-4e9127277114.png">
