### PR TITLE
Add tooltip to breakpoint snippet

### DIFF
--- a/public/js/components/Breakpoints.js
+++ b/public/js/components/Breakpoints.js
@@ -77,7 +77,7 @@ const Breakpoints = React.createClass({
           onChange: () => this.handleCheckbox(breakpoint)
         }),
       dom.div(
-        { className: "breakpoint-label" },
+        { className: "breakpoint-label", title: breakpoint.get("text") },
         `${line} ${snippet}`
       ),
       isPausedIcon


### PR DESCRIPTION
Currently breakpoint info includes only line number and a truncated snippet of code.
I wish there was also the file name, but I couldn't find it in the breakpoint object.
I would ultimately do 2 lines in the breakpoint - first line with `filename.js:line` and second line with smaller grey text of the truncated snippet, plus a tooltip of the full snippet.

This pull request adds only a tooltip of the full snippet.