### PR TITLE
Show hidden sources in a dropdown

### DIFF
--- a/public/js/actions/sources.js
+++ b/public/js/actions/sources.js
@@ -43,7 +43,7 @@ function newSource(source) {
   };
 }
 
-function selectSource(id) {
+function selectSource(id, options = {}) {
   return ({ dispatch, getState, client }) => {
     if (!client) {
       // No connection, do nothing. This happens when the debugger is
@@ -58,7 +58,8 @@ function selectSource(id) {
 
     dispatch({
       type: constants.SELECT_SOURCE,
-      source: source
+      source: source,
+      options
     });
   };
 }

--- a/public/js/components/App.css
+++ b/public/js/components/App.css
@@ -32,3 +32,7 @@ body {
   position: relative;
   flex: 1;
 }
+
+.subsettings:hover {
+  cursor: pointer;
+}

--- a/public/js/components/Dropdown.css
+++ b/public/js/components/Dropdown.css
@@ -1,0 +1,24 @@
+.dropdown {
+  background: white;
+  border: 1px solid var(--theme-gray);
+  width: 150px;
+  max-height: 300px;
+  z-index: 1000;
+}
+
+.dropdown li {
+  padding-left: 10px;
+}
+
+.dropdown li:hover {
+  background: var(--theme-tab-toolbar-background);
+  cursor: pointer;
+}
+
+.dropdown ul {
+  list-style: none;
+  line-height: 2em;
+  font-size: 0.8em;
+  margin: 0;
+  padding: 0;
+}

--- a/public/js/components/RightSidebar.css
+++ b/public/js/components/RightSidebar.css
@@ -27,7 +27,7 @@
   margin-right: 2em;
 }
 
-.subSettings {
+.command-bar .subSettings {
   float: right;
 }
 

--- a/public/js/components/SourceTabs.css
+++ b/public/js/components/SourceTabs.css
@@ -1,7 +1,11 @@
-.source-tabs {
-  height: 30px;
-  width: 100%;
+.source-header {
   border-bottom: 1px solid var(--theme-gray);
+  height: 30px;
+  flex: 1;
+}
+
+.source-tabs {
+  width: calc(100% - 30px);
   overflow: hidden;
 }
 
@@ -39,4 +43,16 @@
   position: absolute;
   right: 7px;
   top: 1px;
+}
+
+.source-header .subsettings {
+  position: absolute;
+  right: 3px;
+  top: 9px;
+}
+
+.sources-dropdown {
+  position: absolute;
+  top: 35px;
+  right: 0px;
 }

--- a/public/js/components/SourceTabs.js
+++ b/public/js/components/SourceTabs.js
@@ -1,7 +1,8 @@
 "use strict";
 
 const React = require("react");
-const { DOM: dom } = React;
+const { DOM: dom, PropTypes } = React;
+const ImPropTypes = require("react-immutable-proptypes");
 const { connect } = require("react-redux");
 const { bindActionCreators } = require("redux");
 const Isvg = React.createFactory(require("react-inlinesvg"));
@@ -12,6 +13,7 @@ const actions = require("../actions");
 const { isEnabled } = require("../../../config/feature");
 
 require("./SourceTabs.css");
+require("./Dropdown.css");
 
 /**
  * TODO: this is a placeholder function
@@ -30,45 +32,158 @@ function getFilename(url) {
   return endTruncateStr(name, 50);
 }
 
-function sourceTab(source, selectedSource, selectSource, closeTab) {
-  const url = source && source.get("url");
-  const filename = getFilename(url);
-  const active = source.equals(selectedSource);
-
-  function onClickClose(ev) {
-    ev.stopPropagation();
-    closeTab(source.get("id"));
+/*
+ * Finds the hidden tabs by comparing the tabs' top offset.
+ * hidden tabs will have a great top offset.
+ *
+ * @param sourceTabs Immutable.list
+ * @param sourceTabEls HTMLCollection
+ *
+ * @returns Immutable.list
+ */
+function getHiddenTabs(sourceTabs, sourceTabEls) {
+  sourceTabEls = [].slice.call(sourceTabEls);
+  function getTopOffset() {
+    const topOffsets = sourceTabEls.map(t => t.getBoundingClientRect().top);
+    return Math.min(...topOffsets);
   }
 
-  return dom.div(
-    {
-      className: classnames("source-tab", { active }),
-      key: source.get("id"),
-      onClick: () => selectSource(source.get("id"))
+  const tabTopOffset = getTopOffset();
+  return sourceTabs.filter((tab, index) => {
+    return sourceTabEls[index].getBoundingClientRect().top > tabTopOffset;
+  });
+}
+
+const SourceTabs = React.createClass({
+  propTypes: {
+    sourceTabs: ImPropTypes.list,
+    selectedSource: ImPropTypes.map,
+    selectSource: PropTypes.func.isRequired,
+    closeTab: PropTypes.func.isRequired
+  },
+
+  displayName: "SourceTabs",
+
+  getInitialState() {
+    return {
+      dropdownShown: false,
+      hiddenSourceTabs: null
+    };
+  },
+
+  componentDidUpdate() {
+    this.updateHiddenSourceTabs(this.props.sourceTabs);
+  },
+
+  /*
+   * Updates the hiddenSourceTabs state, by
+   * finding the source tabs who have wrapped and are not on the top row.
+   */
+  updateHiddenSourceTabs(sourceTabs) {
+    const sourceTabEls = this.refs.sourceTabs.children;
+    const hiddenSourceTabs = getHiddenTabs(sourceTabs, sourceTabEls);
+
+    if (!hiddenSourceTabs.equals(this.state.hiddenSourceTabs)) {
+      this.setState({ hiddenSourceTabs });
+    }
+  },
+
+  toggleSourcesDropdown(e) {
+    this.setState({
+      dropdownShown: !this.state.dropdownShown,
+    });
+  },
+
+  renderSourcesDropdown() {
+    if (!this.state.hiddenSourceTabs) {
+      return dom.div({});
+    }
+
+    return dom.div({
+      className: "sources-dropdown dropdown",
+      ref: "sourcesDropdown",
+      style: { display: (this.state.dropdownShown ? "block" : "none") }
     },
-    dom.div({ className: "filename" }, filename),
-    dom.div({ onClick: onClickClose },
-      Isvg({
-        className: "close-btn",
-        src: "images/close.svg",
-      })
-    )
-  );
-}
+      dom.ul({}, this.state.hiddenSourceTabs.map(this.renderDropdownSource))
+    );
+  },
 
-function SourceTabs({ selectedSource, sourceTabs, selectSource, closeTab }) {
-  function renderTab(source) {
-    return sourceTab(source, selectedSource, selectSource, closeTab);
+  renderDropdownSource(source) {
+    const { selectSource } = this.props;
+    const url = source && source.get("url");
+    const filename = getFilename(url);
+
+    return dom.li({
+      key: source.get("id"),
+      onClick: () => {
+        selectSource(source.get("id"), { position: 0 });
+        this.toggleSourcesDropdown();
+      }
+    }, filename);
+  },
+
+  renderSourcesDropdownButon() {
+    const hiddenSourceTabs = this.state.hiddenSourceTabs;
+    if (!hiddenSourceTabs || hiddenSourceTabs.size == 0) {
+      return dom.div({});
+    }
+
+    return dom.span(
+      {
+        className: "subsettings",
+        onClick: this.toggleSourcesDropdown
+      },
+      dom.img({ src: "images/subSettings.svg" })
+    );
+  },
+
+  renderTabs() {
+    const sourceTabs = this.props.sourceTabs;
+    return dom.div(
+      { className: "source-tabs", ref: "sourceTabs" },
+      sourceTabs.map(this.renderTab)
+    );
+  },
+
+  renderTab(source) {
+    const { selectedSource, selectSource, closeTab } = this.props;
+    const url = source && source.get("url");
+    const filename = getFilename(url);
+    const active = source.equals(selectedSource);
+
+    function onClickClose(ev) {
+      ev.stopPropagation();
+      closeTab(source.get("id"));
+    }
+
+    return dom.div(
+      {
+        className: classnames("source-tab", { active }),
+        key: source.get("id"),
+        onClick: () => selectSource(source.get("id"))
+      },
+      dom.div({ className: "filename" }, filename),
+      dom.div({ onClick: onClickClose },
+        Isvg({
+          className: "close-btn",
+          src: "images/close.svg",
+        })
+      )
+    );
+  },
+
+  render() {
+    if (!isEnabled("features.tabs")) {
+      return "";
+    }
+
+    return dom.div({ className: "source-header" },
+      this.renderSourcesDropdown(),
+      this.renderTabs(),
+      this.renderSourcesDropdownButon()
+    );
   }
-
-  return (
-    dom.div({ className: "source-tabs" },
-      isEnabled("features.tabs")
-        ? sourceTabs.map(renderTab)
-        : renderTab(selectedSource)
-    )
-  );
-}
+});
 
 module.exports = connect(
   state => ({

--- a/public/js/components/tests/SourceTabs.js
+++ b/public/js/components/tests/SourceTabs.js
@@ -34,7 +34,6 @@ describe("SourceTabs", function() {
     setConfig(prevConfig);
 
     const tabs = getSourceTabs($el);
-    expect(tabs.length).to.equal(1);
-    expect(getTitle(tabs[0])).to.equal("todo.js");
+    expect(tabs.length).to.equal(0);
   });
 });

--- a/public/js/reducers/sources.js
+++ b/public/js/reducers/sources.js
@@ -30,13 +30,17 @@ function update(state = initialState, action) {
 
     case constants.SELECT_SOURCE:
       return state
-        .merge({ selectedSource: action.source })
-        .set("tabs", addSourceToTabList(state, fromJS(action.source)));
+        .merge({
+          selectedSource: action.source,
+          tabs: updateTabList(state, fromJS(action.source), action.options)
+        });
 
     case constants.CLOSE_TAB:
       return state
-        .set("tabs", removeSourceFromTabList(state, action.id))
-        .merge({ selectedSource: getNewSelectedSource(state, action.id) });
+        .merge({
+          selectedSource: getNewSelectedSource(state, action.id),
+          tabs: removeSourceFromTabList(state, action.id)
+        });
 
     case constants.LOAD_SOURCE_TEXT: {
       return _updateText(state, action);
@@ -106,12 +110,19 @@ function removeSourceFromTabList(state, id) {
 /*
  * Adds the new source to the tab list if it is not already there
  */
-function addSourceToTabList(state, source) {
+function updateTabList(state, source, options) {
   const tabs = state.get("tabs");
   const selectedSource = state.get("selectedSource");
   const selectedSourceIndex = tabs.indexOf(selectedSource);
+  const sourceIndex = tabs.indexOf(source);
 
   if (tabs.includes(source)) {
+    if (options.position != undefined) {
+      return tabs
+        .delete(sourceIndex)
+        .insert(options.position, source);
+    }
+
     return tabs;
   }
 


### PR DESCRIPTION
This PR adds a dropdown for showing hidden sources
![](http://g.recordit.co/0xJq32JTHI.gif)

It's a relatively low priority, but was fun to work on on the plane.

The implementation is fairly simple, find the tabs who's offset suggest they're not in the top row. Surprisingly there were many other details:
+ only show the dropdown button if there are hidden tabs
+ select a tab should move it to the front

I chose to do a very simple dropdown panel. We should use a better one soon. Also, we should consider a context-menu element that uses the same API, so in the toolbox we can fall back on that. I believe @bgrins has one that works like this
