### PR TITLE
add line numbers to frame source location

### DIFF
--- a/public/js/components/Frames.css
+++ b/public/js/components/Frames.css
@@ -19,6 +19,7 @@
 .frames .location {
   float: right;
   color: #666666;
+  font-weight: lighter;
 }
 
 .frames .title {

--- a/public/js/components/Frames.js
+++ b/public/js/components/Frames.js
@@ -20,10 +20,11 @@ function renderFrameTitle(frame) {
 
 function renderFrameLocation(frame) {
   const url = frame.source.url ? basename(frame.source.url) : "";
-  return div(
-    { className: "location" },
-    endTruncateStr(url, 30)
-  );
+  const line = url !== "" ? `: ${frame.location.line}` : "";
+  return url !== "" ?
+    div({ className: "location" },
+      `${endTruncateStr(url, 30)}${line}`
+    ) : null;
 }
 
 function renderFrame(frame, selectedFrame, selectFrame) {

--- a/public/js/components/tests/Frames.js
+++ b/public/js/components/tests/Frames.js
@@ -34,7 +34,10 @@ describe("Frames", function() {
     const frames = getFrames($el);
     expect(frames.length).to.equal(6);
     expect(getFrameTitle(frames[0])).to.equal("app.TodoView<.updateOnEnter");
-    expect(getFrameLocation(frames[0])).to.equal("todo-view.js");
+    expect(getFrameLocation(frames[0])).to.equal("todo-view.js: 113");
+    expect(getFrameTitle(frames[3])).to.equal("sendKey");
+    // lastChild is the firstChild, there is no empty div present
+    expect(getFrameLocation(frames[3])).to.equal("sendKey");
   });
 
   it("Nested Closure", function() {
@@ -46,6 +49,6 @@ describe("Frames", function() {
     const frames = getFrames($el);
     expect(frames.length).to.equal(5);
     expect(getFrameTitle(frames[0])).to.equal("pythagorean");
-    expect(getFrameLocation(frames[0])).to.equal("pythagorean.js");
+    expect(getFrameLocation(frames[0])).to.equal("pythagorean.js: 11");
   });
 });


### PR DESCRIPTION
adds a line number to the source location if the source location exists
if there is no source location it no longer adds an empty element
also lightens the text a bit, hopefully @helenvholmes is cool with that

<img width="329" alt="screen shot 2016-07-08 at 3 56 53 pm" src="https://cloud.githubusercontent.com/assets/2134/16703897/49dcf40a-4526-11e6-89bf-7b129b311675.png">
