### PR TITLE
Use Firefox WebSocket transport instead of the WS/TCP proxy

### DIFF
--- a/bin/development-server.js
+++ b/bin/development-server.js
@@ -18,8 +18,10 @@ const feature = require("../config/feature");
 const config = getConfig();
 feature.setConfig(config);
 
-// const firefoxProxy = require("./firefox-proxy");
-// firefoxProxy({ logging: feature.isEnabled("logging.firefoxProxy") });
+if (!feature.isEnabled("firefox.webSocketConnection")) {
+  const firefoxProxy = require("./firefox-proxy");
+  firefoxProxy({ logging: feature.isEnabled("logging.firefoxProxy") });
+}
 
 function httpGet(url, onResponse) {
   return http.get(url, (response) => {

--- a/bin/development-server.js
+++ b/bin/development-server.js
@@ -18,8 +18,8 @@ const feature = require("../config/feature");
 const config = getConfig();
 feature.setConfig(config);
 
-const firefoxProxy = require("./firefox-proxy");
-firefoxProxy({ logging: feature.isEnabled("logging.firefoxProxy") });
+// const firefoxProxy = require("./firefox-proxy");
+// firefoxProxy({ logging: feature.isEnabled("logging.firefoxProxy") });
 
 function httpGet(url, onResponse) {
   return http.get(url, (response) => {

--- a/bin/firefox-driver.js
+++ b/bin/firefox-driver.js
@@ -21,6 +21,7 @@ function firefoxProfile() {
   profile.setPreference("devtools.debugger.remote-enabled",  true);
   profile.setPreference("devtools.chrome.enabled",  true);
   profile.setPreference("devtools.debugger.prompt-connection",  false);
+  profile.setPreference("devtools.debugger.remote-use-websocket", true);
 
   return profile;
 }

--- a/bin/firefox-driver.js
+++ b/bin/firefox-driver.js
@@ -7,6 +7,7 @@ const until = webdriver.until;
 const Key = webdriver.Key;
 
 const shouldStart = process.argv.indexOf("--start") > 0;
+const useWebSocket = process.argv.indexOf("--websocket") > 0;
 
 function firefoxBinary() {
   var binary = new firefox.Binary();
@@ -21,7 +22,7 @@ function firefoxProfile() {
   profile.setPreference("devtools.debugger.remote-enabled",  true);
   profile.setPreference("devtools.chrome.enabled",  true);
   profile.setPreference("devtools.debugger.prompt-connection",  false);
-  profile.setPreference("devtools.debugger.remote-use-websocket", true);
+  profile.setPreference("devtools.debugger.remote-use-websocket", useWebSocket);
 
   return profile;
 }

--- a/config/development.json
+++ b/config/development.json
@@ -12,6 +12,8 @@
     "webSocketPort": 9222
   },
   "firefox": {
+    "proxyPort": 9000,
+    "webSocketConnection": true,
     "webSocketPort": 6080
   }
 }

--- a/config/development.json
+++ b/config/development.json
@@ -12,6 +12,6 @@
     "webSocketPort": 9222
   },
   "firefox": {
-    "webSocketPort": 9000
+    "webSocketPort": 6080
   }
 }

--- a/config/development.json
+++ b/config/development.json
@@ -13,7 +13,7 @@
   },
   "firefox": {
     "proxyPort": 9000,
-    "webSocketConnection": true,
+    "webSocketConnection": false,
     "webSocketPort": 6080
   }
 }

--- a/public/js/clients/firefox.js
+++ b/public/js/clients/firefox.js
@@ -2,6 +2,7 @@
 
 const { DebuggerClient } = require("devtools-sham/shared/client/main");
 const { DebuggerTransport } = require("devtools-sham/transport/transport");
+const WebSocketDebuggerTransport = require("devtools-sham/transport/ws-transport");
 const { TargetFactory } = require("devtools-sham/client/framework/target");
 const defer = require("../lib/devtools/shared/defer");
 const { getValue } = require("../../../config/feature");
@@ -49,10 +50,13 @@ function createTabs(tabs) {
 function connectClient() {
   const deferred = defer();
   let isConnected = false;
-  const webSocketPort = getValue("firefox.webSocketPort");
+  const useProxy = !getValue("firefox.webSocketConnection");
+  const portPref = useProxy ? "firefox.proxyPort" : "firefox.webSocketPort";
+  const webSocketPort = getValue(portPref);
 
   const socket = new WebSocket(`ws://localhost:${webSocketPort}`);
-  const transport = new DebuggerTransport(socket);
+  const transport = useProxy ?
+    new DebuggerTransport(socket) : new WebSocketDebuggerTransport(socket);
   debuggerClient = new DebuggerClient(transport);
 
   // TODO: the timeout logic should be moved to DebuggerClient.connect.

--- a/public/js/lib/devtools-sham/transport/ws-transport.js
+++ b/public/js/lib/devtools-sham/transport/ws-transport.js
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const EventEmitter = require("devtools-sham/shared/event-emitter");
+
+function WebSocketDebuggerTransport(socket) {
+  EventEmitter.decorate(this);
+
+  this._ws = socket;
+
+  this.active = false;
+  this.hooks = null;
+}
+
+WebSocketDebuggerTransport.prototype = {
+  ready() {
+    if (!this.active) {
+      this.active = true;
+      this._ws.onmessage = this._onMessage.bind(this);
+    }
+  },
+
+  send(object) {
+    this.emit("send", object);
+    this._ws.send(JSON.stringify(object));
+  },
+
+  _onMessage(event) {
+    let object = JSON.parse(event.data);
+    this.emit("onPacket", object);
+    if (this.hooks) {
+      this.hooks.onPacket(object);
+    }
+  },
+
+  close(reason) {
+    this.emit("onClosed", reason);
+
+    this.active = false;
+    this._ws.close();
+    if (this.hooks) {
+      this.hooks.onClosed(reason);
+      this.hooks = null;
+    }
+  },
+};
+
+module.exports = WebSocketDebuggerTransport;


### PR DESCRIPTION
Turn on the Firefox WebSocket debugger server and use it instead of the proxy:
- enable the `devtools.debugger.remote-use-websocket` pref
- comment out spawning the proxy
- change the `webSocketPort` to 6080 - we are connecting directly to Firefox now

Your Firefox needs to be built with the WebSocket patch from [bug 1286281](https://bugzilla.mozilla.org/show_bug.cgi?id=1286281).