### PR TITLE
convert original to mapped

### DIFF
--- a/public/js/actions/sources.js
+++ b/public/js/actions/sources.js
@@ -13,8 +13,8 @@ const constants = require("../constants");
 const Prefs = require("../prefs");
 const invariant = require("invariant");
 const { isEnabled } = require("../../../config/feature");
-const { loadOriginalSources, isOriginal,
-        getOriginalSource } = require("../util/source-map");
+const { loadMappedSources, isMapped,
+        getMappedSource } = require("../util/source-map");
 
 /**
  * Throttles source dispatching to reduce rendering churn.
@@ -41,7 +41,7 @@ function newSource(source) {
   return ({ dispatch, getState }) => {
     if (isEnabled("features.sourceMaps") && source.sourceMapURL) {
       const tab = getSelectedTab(getState());
-      loadOriginalSources(tab, source)
+      loadMappedSources(tab, source)
         .then(sources => sources.forEach(s => dispatch(newSource(s))));
     }
 
@@ -181,8 +181,8 @@ function loadSourceText(source) {
         // let histogram = Services.telemetry.getHistogramById(histogramId);
         // let startTime = Date.now();
 
-        const response = isOriginal(source)
-          ? yield getOriginalSource(source, getState, dispatch, loadSourceText)
+        const response = isMapped(source)
+          ? yield getMappedSource(source, getState, dispatch, loadSourceText)
           : yield client.sourceContents(source.id);
 
         // histogram.add(Date.now() - startTime);

--- a/public/js/util/source-map.js
+++ b/public/js/util/source-map.js
@@ -23,7 +23,7 @@ function getOriginalSources(sourceId) {
   return consumer.sources;
 }
 
-function isOriginal(originalSource) {
+function isMapped(originalSource) {
   return !!getGeneratedSourceId(originalSource);
 }
 
@@ -69,7 +69,7 @@ function getOriginalSourceContent(originalSource, generatedSource, text) {
   return sourceNode.sourceContents[originalSource.url];
 }
 
-function loadOriginalSources(tab, generatedSource) {
+function loadMappedSources(tab, generatedSource) {
   return loadSourceMap(tab, generatedSource).then(() => {
     return getOriginalSources(generatedSource.id)
       .map((source, index) => Source({
@@ -80,7 +80,7 @@ function loadOriginalSources(tab, generatedSource) {
   });
 }
 
-function getOriginalSource(originalSource, getState, dispatch, loadSourceText) {
+function getMappedSource(originalSource, getState, dispatch, loadSourceText) {
   return Task.spawn(function* () {
     const generatedSource = getSource(
       getState(),
@@ -105,7 +105,7 @@ function getOriginalSource(originalSource, getState, dispatch, loadSourceText) {
 }
 
 module.exports = {
-  loadOriginalSources,
-  getOriginalSource,
-  isOriginal
+  loadMappedSources,
+  getMappedSource,
+  isMapped
 };


### PR DESCRIPTION
Small naming change. The idea is to talk about sources in the action layer in terms of sources that either come from the server or are mapped client side.

e.g. bundle.js is a source that has 3 mapped sources math.js, increment.js, sum.js

Not sure if this is the best naming or works in all of the cases.
