### PR TITLE
show the __proto__ value in the object inspector (fixes #319)

### DIFF
--- a/public/js/components/ObjectInspector.js
+++ b/public/js/components/ObjectInspector.js
@@ -72,6 +72,29 @@ const ObjectInspector = React.createClass({
     return {};
   },
 
+  makeNodesForProperties(props, parentPath) {
+    const { ownProperties, prototype } = props;
+
+    const nodes = Object.keys(ownProperties).filter(name => {
+      // Ignore non-concrete values like getters and setters
+      // for now by making sure we have a value.
+      return "value" in ownProperties[name];
+    }).map(name => {
+      return createNode(name, parentPath + "/" + name, ownProperties[name]);
+    });
+
+    // Add the prototype if it exists and is not null
+    if (prototype && prototype.type !== "null") {
+      nodes.push(createNode(
+        "__proto__",
+        parentPath + "/__proto__",
+        { value: prototype }
+      ));
+    }
+
+    return nodes;
+  },
+
   getChildren(item) {
     const { getObjectProperties } = this.props;
     const obj = item.contents;
@@ -93,14 +116,11 @@ const ObjectInspector = React.createClass({
         return this.actorCache[actor];
       }
 
-      const loaded = getObjectProperties(actor);
-      if (loaded) {
-        this.actorCache[actor] = loaded.map(child => {
-          // This is where the path is constructed.
-          return createNode(child[0], item.path + "/" + child[0], child[1]);
-        });
-
-        return this.actorCache[actor];
+      const loadedProps = getObjectProperties(actor);
+      if (loadedProps) {
+        const children = this.makeNodesForProperties(loadedProps, item.path);
+        this.actorCache[actor] = children;
+        return children;
       }
       return [];
     }

--- a/public/js/reducers/pause.js
+++ b/public/js/reducers/pause.js
@@ -44,17 +44,11 @@ function update(state = initialState, action, emit) {
 
     case constants.LOAD_OBJECT_PROPERTIES:
       if (action.status === "done") {
-        const props = action.value.ownProperties;
+        const ownProperties = action.value.ownProperties;
+        const prototype = action.value.prototype;
 
-        return state.setIn(
-          ["loadedObjects", action.objectId],
-          Object.keys(props)
-            .filter(name => {
-              return name !== "prototype" && "value" in props[name];
-            })
-            .sort((a, b) => a.localeCompare(b))
-            .map(name => [name, props[name]])
-        );
+        return state.setIn(["loadedObjects", action.objectId],
+                           { ownProperties, prototype });
       }
       break;
 


### PR DESCRIPTION
**Don't merge this**. As I was typing this out I realized that this work should happening in the `ObjectInspector` component. I will probably make the `loadedObjects` map contain all the info needed to construct this data. I'll change this PR tomorrow.