### PR TITLE
autocomplete UI tweaks: center icon and focus outline

### DIFF
--- a/public/js/components/Autocomplete.css
+++ b/public/js/components/Autocomplete.css
@@ -51,10 +51,9 @@
   font-size: 0.8em;
   background-image: url("/images/magnifying-glass.svg");
   background-repeat: no-repeat;
-  background-position-y: calc(1.25em - 8px);
-  background-position-x: 5px;
+  background-position: 5px 50%;
 }
 
 .autocomplete input:focus {
-  outline: 2px solid #4a90e0;
+  border-color: #4a90e0;
 }


### PR DESCRIPTION
Since longhand background-position-* are only implemented starting firefox 49, I thought they aren't necessary in this case.
Also, I thought that using the border rather than outline is better for focus state in this case since otherwise both of them show up