### PR TITLE
Translate breakpoint locations to original locations

### DIFF
--- a/public/js/selectors.js
+++ b/public/js/selectors.js
@@ -11,6 +11,10 @@ type AppState = {
   pause: any
 }
 
+const { isGenerated, getGeneratedSourceLocation,
+        isOriginal, getOriginalSourcePosition
+      } = require("./util/source-map");
+
 /* Selectors */
 function getSources(state: AppState) {
   return state.sources.sources;
@@ -99,6 +103,43 @@ function getSourceMapURL(state: AppState, source: Source) {
   return tab.get("url") + "/" + source.sourceMapURL;
 }
 
+function getGeneratedLocation(state: AppState, location: Location) {
+  const source = getSource(state, location.sourceId);
+
+  if (!source) {
+    return location;
+  }
+
+  if (isOriginal(source.toJS())) {
+    return getGeneratedSourceLocation(source.toJS(), location);
+  }
+
+  return location;
+}
+
+function getOriginalLocation(state: AppState, location) {
+  const source = getSource(state, location.sourceId);
+
+  if (!source) {
+    return location;
+  }
+
+  if (isGenerated(source.toJS())) {
+    const { url, line } = getOriginalSourcePosition(
+      source.toJS(),
+      location
+    );
+
+    const originalSource = getSourceByURL(state, url);
+    return {
+      sourceId: originalSource.get("id"),
+      line
+    };
+  }
+
+  return location;
+}
+
 /**
  * @param object - location
  */
@@ -117,6 +158,8 @@ module.exports = {
   getSourceMapURL,
   getSelectedSource,
   getSourceText,
+  getOriginalLocation,
+  getGeneratedLocation,
   getBreakpoint,
   getBreakpoints,
   getBreakpointsForSource,

--- a/public/js/util/source-map.js
+++ b/public/js/util/source-map.js
@@ -88,6 +88,19 @@ function getOriginalSource(
   };
 }
 
+function getOriginalSourcePosition(generatedSource, location) {
+  const consumer = _getConsumer(generatedSource.id);
+  const position = consumer.originalPositionFor({
+    line: location.line,
+    column: 0
+  });
+
+  return {
+    url: position.source,
+    line: position.line
+  };
+}
+
 function createOriginalSources(generatedSource, sourceMap) {
   if (!_hasConsumer(generatedSource.id)) {
     _setConsumer(generatedSource, sourceMap);
@@ -102,6 +115,7 @@ function createOriginalSources(generatedSource, sourceMap) {
 
 module.exports = {
   getOriginalSource,
+  getOriginalSourcePosition,
   getGeneratedSourceLocation,
   createOriginalSources,
   isOriginal,


### PR DESCRIPTION
I can't believe how much cleaner this approach is from before. 

Things fell in line really nicely:
+ selectors translate locations
+ source map acquired a couple useful helpers
+ client is wrapped so that it receives generated locations

This probably could be dried up further, but it shows promise