### PR TITLE
load original sources

### DIFF
--- a/public/js/actions/tests/loadSourceText.js
+++ b/public/js/actions/tests/loadSourceText.js
@@ -1,4 +1,5 @@
 const { Task } = require("../../util/task");
+const fromJS = require("../../util/fromJS");
 const expect = require("expect.js");
 
 const { actions, selectors, createStore } = require("../../util/test-head");
@@ -46,7 +47,7 @@ describe("loadSourceText", () => {
   it("loading one source text", function(done) {
     Task.spawn(function* () {
       const store = createStore(simpleMockThreadClient);
-      yield store.dispatch(actions.loadSourceText({ id: "foo1" }));
+      yield store.dispatch(actions.loadSourceText(fromJS({ id: "foo1" })));
 
       const fooSourceText = getSourceText(store.getState(), "foo1");
       expect(fooSourceText.get("text")).to.equal(sourceText.foo1.source);
@@ -57,8 +58,8 @@ describe("loadSourceText", () => {
   it("loading two different sources", function(done) {
     Task.spawn(function* () {
       const store = createStore(simpleMockThreadClient);
-      yield store.dispatch(loadSourceText({ id: "foo1" }));
-      yield store.dispatch(loadSourceText({ id: "foo2" }));
+      yield store.dispatch(loadSourceText(fromJS({ id: "foo1" })));
+      yield store.dispatch(loadSourceText(fromJS({ id: "foo2" })));
 
       const fooSourceText = getSourceText(store.getState(), "foo1");
       expect(fooSourceText.get("text")).to.equal(sourceText.foo1.source);
@@ -74,8 +75,8 @@ describe("loadSourceText", () => {
     const store = createStore(simpleMockThreadClient);
 
     Task.spawn(function* () {
-      yield store.dispatch(loadSourceText({ id: "foo1" }));
-      yield store.dispatch(loadSourceText({ id: "foo1" }));
+      yield store.dispatch(loadSourceText(fromJS({ id: "foo1" })));
+      yield store.dispatch(loadSourceText(fromJS({ id: "foo1" })));
       const fooSourceText = getSourceText(store.getState(), "foo1");
       expect(fooSourceText.get("text")).to.equal(sourceText.foo1.source);
 
@@ -87,7 +88,7 @@ describe("loadSourceText", () => {
     const store = createStore(deferredMockThreadClient);
     // We're intentionally not yielding here to check the loading
     // state
-    store.dispatch(loadSourceText({ id: "foo1" }));
+    store.dispatch(loadSourceText(fromJS({ id: "foo1" })));
     const fooSourceText = getSourceText(store.getState(), "foo1");
     expect(fooSourceText.get("loading")).to.equal(true);
   });
@@ -95,7 +96,8 @@ describe("loadSourceText", () => {
   it("source failed to load", function() {
     return Task.spawn(function* () {
       const store = createStore(deferredMockThreadClient);
-      yield store.dispatch(loadSourceText({ id: "badId" })).catch(() => {});
+      yield store.dispatch(loadSourceText(fromJS({ id: "badId" })))
+                 .catch(() => {});
 
       const fooSourceText = getSourceText(store.getState(), "badId");
       expect(fooSourceText.get("error")).to.equal("failed to load");

--- a/public/js/actions/types.js
+++ b/public/js/actions/types.js
@@ -4,8 +4,15 @@ export type AsyncStatus = "start" | "done" | "error";
 
 export type Source = {
   id: string,
-  url?: string
+  url?: string,
+  sourceMapURL?: string
 };
+
+export type SourceText = {
+  id: string,
+  text: string,
+  contentType: string
+}
 
 export type Location = {
   sourceId: string,
@@ -19,10 +26,14 @@ export type Action =
   | { type: "SELECT_SOURCE", source: Source, options: { position?: number } }
   | { type: "CLOSE_TAB", id: string }
   | { type: "LOAD_SOURCE_TEXT",
-      source: Source,
+      generatedSource: Source,
+      originalSources: Array<Source>,
       status: AsyncStatus,
       error: string,
-      value: { text: string, contentType: string }}
+      value: {
+        generatedSourceText: SourceText,
+        originalSourceTexts: Array<SourceText>
+      }}
   | { type: "BLACKBOX",
       source: Source,
       status: AsyncStatus,

--- a/public/js/selectors.js
+++ b/public/js/selectors.js
@@ -2,7 +2,7 @@
 
 import type { Record } from "./util/makeRecord";
 import type { SourcesState } from "./reducers/sources";
-import type { Location, Source } from "./actions/types";
+import type { Location } from "./actions/types";
 
 type AppState = {
   sources: Record<SourcesState>,
@@ -11,8 +11,8 @@ type AppState = {
   pause: any
 }
 
-const { isGenerated, getGeneratedSourceLocation,
-        isOriginal, getOriginalSourcePosition
+const { isGenerated, getGeneratedSourceLocation, getOriginalSourceUrls,
+        isOriginal, getOriginalSourcePosition, getGeneratedSourceId
       } = require("./util/source-map");
 
 /* Selectors */
@@ -98,13 +98,13 @@ function getSourceText(state: AppState, id: string) {
   return getSourcesText(state).get(id);
 }
 
-function getSourceMapURL(state: AppState, source: Source) {
+function getSourceMapURL(state: AppState, source: any) {
   const tab = getSelectedTab(state);
   return tab.get("url") + "/" + source.sourceMapURL;
 }
 
 function getGeneratedLocation(state: AppState, location: Location) {
-  const source = getSource(state, location.sourceId);
+  const source: any = getSource(state, location.sourceId);
 
   if (!source) {
     return location;
@@ -117,8 +117,8 @@ function getGeneratedLocation(state: AppState, location: Location) {
   return location;
 }
 
-function getOriginalLocation(state: AppState, location) {
-  const source = getSource(state, location.sourceId);
+function getOriginalLocation(state: AppState, location: Location) {
+  const source: any = getSource(state, location.sourceId);
 
   if (!source) {
     return location;
@@ -130,7 +130,7 @@ function getOriginalLocation(state: AppState, location) {
       location
     );
 
-    const originalSource = getSourceByURL(state, url);
+    const originalSource: any = getSourceByURL(state, url);
     return {
       sourceId: originalSource.get("id"),
       line
@@ -138,6 +138,21 @@ function getOriginalLocation(state: AppState, location) {
   }
 
   return location;
+}
+
+function getGeneratedSource(state: AppState, source: any) {
+  if (isGenerated(source.toJS())) {
+    return source;
+  }
+
+  const generatedSourceId = getGeneratedSourceId(source.toJS());
+  const originalSource = getSource(state, generatedSourceId);
+  return originalSource || source;
+}
+
+function getOriginalSources(state: AppState, source: any) {
+  const originalSourceUrls = getOriginalSourceUrls(source.toJS());
+  return originalSourceUrls.map(url => getSourceByURL(state, url));
 }
 
 /**
@@ -160,6 +175,8 @@ module.exports = {
   getSourceText,
   getOriginalLocation,
   getGeneratedLocation,
+  getGeneratedSource,
+  getOriginalSources,
   getBreakpoint,
   getBreakpoints,
   getBreakpointsForSource,

--- a/public/js/selectors.js
+++ b/public/js/selectors.js
@@ -11,6 +11,10 @@ type AppState = {
   pause: any
 }
 
+const { isGenerated, getGeneratedSourceLocation,
+        isOriginal, getOriginalSourcePosition
+      } = require("./util/source-map");
+
 /* Selectors */
 function getSources(state: AppState) {
   return state.sources.sources;
@@ -99,6 +103,43 @@ function getSourceMapURL(state: AppState, source: Source) {
   return tab.get("url") + "/" + source.sourceMapURL;
 }
 
+function getGeneratedLocation(state: AppState, location: Location) {
+  const source = getSource(state, location.sourceId);
+
+  if (!source) {
+    return location;
+  }
+
+  if (isOriginal(source.toJS())) {
+    return getGeneratedSourceLocation(source.toJS(), location);
+  }
+
+  return location;
+}
+
+function getOriginalLocation(state: AppState, location) {
+  const source = getSource(state, location.sourceId);
+
+  if (!source) {
+    return location;
+  }
+
+  if (isGenerated(source.toJS())) {
+    const { url, line } = getOriginalSourcePosition(
+      source.toJS(),
+      location
+    );
+
+    const originalSource = getSourceByURL(state, url);
+    return {
+      sourceId: originalSource.get("id"),
+      line
+    };
+  }
+
+  return location;
+}
+
 /**
  * @param object - location
  */
@@ -117,6 +158,8 @@ module.exports = {
   getSourceMapURL,
   getSelectedSource,
   getSourceText,
+  getOriginalLocation,
+  getGeneratedLocation,
   getBreakpoint,
   getBreakpoints,
   getBreakpointsForSource,

--- a/public/js/util/source-map.js
+++ b/public/js/util/source-map.js
@@ -88,6 +88,19 @@ function getOriginalSource(
   };
 }
 
+function getOriginalSourcePosition(generatedSource, location) {
+  const consumer = _getConsumer(generatedSource.id);
+  const position = consumer.originalPositionFor({
+    line: location.line,
+    column: 0
+  });
+
+  return {
+    url: position.source,
+    line: position.line
+  };
+}
+
 function createOriginalSources(generatedSource, sourceMap) {
   if (!_hasConsumer(generatedSource.id)) {
     _setConsumer(generatedSource, sourceMap);
@@ -102,6 +115,7 @@ function createOriginalSources(generatedSource, sourceMap) {
 
 module.exports = {
   getOriginalSource,
+  getOriginalSourcePosition,
   getGeneratedSourceLocation,
   createOriginalSources,
   isOriginal,


### PR DESCRIPTION
This PR fixes issues we had with loading original source text.

**Problem:**
When a user tries to add a breakpoint in a generated source, the breakpoint fails to be added because the original source text has not been "loaded". This is a mistake because once we've loaded the generated source text, we've effectively loaded the original source texts as well. 

**Solution**
Load the original source texts in "loadSourceText" action. This involves updating the loadSourceText action and reducers updateText. UpdateText now expects a list of values (sources or source texts to update). 
