### PR TITLE
(wip) proposal for moving selectors into reducers

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "expect.js": "^0.3.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "firefox-profile": "^0.4.0",
-    "flow-bin": "^0.28.0",
+    "flow-bin": "^0.29.0",
     "glob": "^7.0.3",
     "install": "^0.8.1",
     "json-loader": "^0.5.4",

--- a/public/js/reducers/index.js
+++ b/public/js/reducers/index.js
@@ -11,7 +11,7 @@ const pause = require("./pause");
 
 module.exports = {
   eventListeners,
-  sources,
+  sources: sources.update,
   breakpoints,
   asyncRequests,
   tabs,

--- a/public/js/reducers/tests/sources.js
+++ b/public/js/reducers/tests/sources.js
@@ -3,15 +3,15 @@
 declare var describe: (name: string, func: () => void) => void;
 declare var it: (desc: string, func: () => void) => void;
 
-const sourceReducer = require("../sources");
+const { State, update } = require("../sources");
 const fixtures = require("../../test/fixtures/foobar.json");
 const fakeSources = fixtures.sources.sources;
 const expect = require("expect.js");
 
 describe("sources reducer", () => {
   it("should work", () => {
-    let state = sourceReducer.SourcesState();
-    state = sourceReducer(state, {
+    let state = State();
+    state = update(state, {
       type: "ADD_SOURCE",
       source: fakeSources.fooSourceActor
     });

--- a/public/js/selectors.js
+++ b/public/js/selectors.js
@@ -4,6 +4,8 @@ import type { Record } from "./utils/makeRecord";
 import type { SourcesState } from "./reducers/sources";
 import type { Location } from "./actions/types";
 
+const sources = require("./reducers/sources");
+
 type AppState = {
   sources: Record<SourcesState>,
   breakpoints: any,
@@ -13,27 +15,6 @@ type AppState = {
 const { isGenerated, getGeneratedSourceLocation, getOriginalSourceUrls,
         isOriginal, getOriginalSourcePosition, getGeneratedSourceId
       } = require("./utils/source-map");
-
-/* Selectors */
-function getSources(state: AppState) {
-  return state.sources.sources;
-}
-
-function getSourceTabs(state: AppState) {
-  return state.sources.tabs;
-}
-
-function getSourcesText(state: AppState) {
-  return state.sources.sourcesText;
-}
-
-function getSelectedSource(state: AppState) {
-  return state.sources.selectedSource;
-}
-
-function getSourceMap(state: AppState, sourceId: string) {
-  return state.sources.sourceMaps.get(sourceId);
-}
 
 function getBreakpoint(state: AppState, location: Location) {
   return state.breakpoints.getIn(["breakpoints", makeLocationId(location)]);
@@ -77,33 +58,13 @@ function getSelectedFrame(state: AppState) {
   return state.pause.get("selectedFrame");
 }
 
-function getSource(state: AppState, id: string) {
-  return getSources(state).get(id);
-}
-
-function getSourceCount(state: AppState) {
-  return getSources(state).size;
-}
-
-function getSourceByURL(state: AppState, url: string) {
-  return getSources(state).find(source => source.get("url") == url);
-}
-
-function getSourceById(state: AppState, id: string) {
-  return getSources(state).find(source => source.get("id") == id);
-}
-
-function getSourceText(state: AppState, id: string) {
-  return getSourcesText(state).get(id);
-}
-
 function getSourceMapURL(state: AppState, source: any) {
   const tab = getSelectedTab(state);
   return tab.get("url") + "/" + source.sourceMapURL;
 }
 
 function getGeneratedLocation(state: AppState, location: Location) {
-  const source: any = getSource(state, location.sourceId);
+  const source: any = sources.getSource(state, location.sourceId);
 
   if (!source) {
     return location;
@@ -117,7 +78,7 @@ function getGeneratedLocation(state: AppState, location: Location) {
 }
 
 function getOriginalLocation(state: AppState, location: Location) {
-  const source: any = getSource(state, location.sourceId);
+  const source: any = sources.getSource(state, location.sourceId);
 
   if (!source) {
     return location;
@@ -129,7 +90,7 @@ function getOriginalLocation(state: AppState, location: Location) {
       location
     );
 
-    const originalSource: any = getSourceByURL(state, url);
+    const originalSource: any = sources.getSourceByURL(state, url);
     return {
       sourceId: originalSource.get("id"),
       line
@@ -145,7 +106,7 @@ function getGeneratedSource(state: AppState, source: any) {
   }
 
   const generatedSourceId = getGeneratedSourceId(source);
-  const originalSource = getSource(state, generatedSourceId);
+  const originalSource = sources.getSource(state, generatedSourceId);
 
   if (originalSource) {
     return originalSource.toJS();
@@ -156,7 +117,7 @@ function getGeneratedSource(state: AppState, source: any) {
 
 function getOriginalSources(state: AppState, source: any) {
   const originalSourceUrls = getOriginalSourceUrls(source);
-  return originalSourceUrls.map(url => getSourceByURL(state, url));
+  return originalSourceUrls.map(url => sources.getSourceByURL(state, url));
 }
 
 /**
@@ -167,20 +128,21 @@ function makeLocationId(location: Location) {
 }
 
 module.exports = {
-  getSource,
-  getSources,
-  getSourceMap,
-  getSourceTabs,
-  getSourceCount,
-  getSourceByURL,
-  getSourceById,
-  getSourceMapURL,
-  getSelectedSource,
-  getSourceText,
+  getSource: sources.getSource,
+  getSourceByURL: sources.getSourceByURL,
+  getSourceById: sources.getSourceById,
+  getSources: sources.getSources,
+  getSourceText: sources.getSourceText,
+  getSourceTabs: sources.getSourceTabs,
+  getSelectedSource: sources.getSelectedSource,
+  getSourceMap: sources.getSourceMap,
+
   getOriginalLocation,
   getGeneratedLocation,
   getGeneratedSource,
   getOriginalSources,
+  getSourceMapURL,
+
   getBreakpoint,
   getBreakpoints,
   getBreakpointsForSource,

--- a/public/js/utils/dehydrate-state.js
+++ b/public/js/utils/dehydrate-state.js
@@ -1,6 +1,6 @@
 const I = require("immutable");
 const { fromJS } = I;
-const SourcesState = require("../reducers/sources").SourcesState;
+const SourcesState = require("../reducers/sources").State;
 
 function dehydrate(jsState) {
   return {

--- a/public/js/utils/makeRecord.js
+++ b/public/js/utils/makeRecord.js
@@ -22,10 +22,9 @@ export type Record<T: Object> = {
  * record factory function
  */
 function makeRecord<T>(
-  spec: T & Object,
-  name: string
+  spec: T & Object
 ): (init: $Shape<T>) => Record<T> {
-  return I.Record(spec, name);
+  return I.Record(spec);
 }
 
 module.exports = makeRecord;


### PR DESCRIPTION
Don't merge this quite yet, I might make a final round of tweaks. But this shows you what it will look like.

Unfortunately, as the comment explains, it's not quite as clean as I would like. I would have loved for the selectors to just take the "sources" state and work with it directly, but unfortunately that's hard. We still want to expose a single module that the UI can require to get access to the selectors, and be able pass top-level app state into them (`getSources(appState, ...)`). This means we need to import all the selectors, "wrap" them so they pick off the right sub-state, and call the selector from the reducer.

But that's impossible to type. This is as close as I got: https://gist.github.com/jlongster/591b785b74a9ba0627e8e5241a30607f Unfortunately, because Flow requires explicit annotations on exported functions, it's really hard to come up with a generic `wrap` that will satisfy it. We might be able to figure it out later, but I need to stop spending time on this.