### PR TITLE
Add full URL as tab title

### DIFF
--- a/public/js/components/SourceTabs.js
+++ b/public/js/components/SourceTabs.js
@@ -175,7 +175,8 @@ const SourceTabs = React.createClass({
       {
         className: classnames("source-tab", { active }),
         key: source.get("id"),
-        onClick: () => selectSource(source.get("id"))
+        onClick: () => selectSource(source.get("id")),
+        title: url
       },
       dom.div({ className: "filename" }, filename),
       dom.div(


### PR DESCRIPTION
I find it helpful in tab situations when the full URL or path to file is show-on-hover with the tab.  

Just a suggestion, feel free to close.