### PR TITLE
apply flow to breakpoints reducer, move breakpoints selectors, and convert to JS types

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -34,6 +34,9 @@ module.exports = function(config) {
       "./public/js/**/tests/*": ["webpack"]
     },
 
-    webpack: webpackConfig
+    webpack: webpackConfig,
+    webpackMiddleware: {
+      noInfo: true
+    }
   });
 };

--- a/public/js/actions/types.js
+++ b/public/js/actions/types.js
@@ -2,6 +2,21 @@
 
 export type AsyncStatus = "start" | "done" | "error";
 
+export type Location = {
+  sourceId: string,
+  line: number,
+  column?: number
+};
+
+export type Breakpoint = {
+  id: string,
+  location: Location,
+  loading: boolean,
+  disabled: boolean,
+  text: string,
+  condition: ?string
+};
+
 export type Source = {
   id: string,
   url?: string,
@@ -12,19 +27,30 @@ export type SourceText = {
   id: string,
   text: string,
   contentType: string
-}
+};
 
-export type Location = {
-  sourceId: string,
-  line: number,
-  column?: number
-}
+type BreakpointAction =
+  { type: "ADD_BREAKPOINT",
+    breakpoint: Breakpoint,
+    condition: string,
+    status: AsyncStatus,
+    error: string,
+    value: { actualLocation: Location, id: string, text: string } }
+  | { type: "REMOVE_BREAKPOINT",
+      breakpoint: Breakpoint,
+      status: AsyncStatus,
+      error: string,
+      disabled: boolean }
+  | { type: "SET_BREAKPOINT_CONDITION",
+      breakpoint: Breakpoint,
+      condition: string,
+      status: AsyncStatus,
+      error: string };
 
-export type Action =
+type SourceAction =
   { type: "ADD_SOURCE", source: Source }
   | { type: "ADD_SOURCES", sources: Array<Source> }
   | { type: "SELECT_SOURCE", source: Source, options: { position?: number } }
-  | { type: "CLOSE_TAB", id: string }
   | { type: "LOAD_SOURCE_TEXT",
       generatedSource: Source,
       originalSources: Array<Source>,
@@ -46,4 +72,9 @@ export type Action =
       value: { isPrettyPrinted: boolean,
                text: string,
                contentType: string }}
+  | { type: "CLOSE_TAB", id: string };
+
+export type Action =
+  SourceAction
+  | BreakpointAction
   | { type: "NAVIGATE" };

--- a/public/js/components/App.js
+++ b/public/js/components/App.js
@@ -13,15 +13,14 @@ const RightSidebar = createFactory(require("./RightSidebar"));
 const SourceTabs = createFactory(require("./SourceTabs"));
 const SourceFooter = createFactory(require("./SourceFooter"));
 const Autocomplete = createFactory(require("./Autocomplete"));
-const { getSelectedSource, getSources, getBreakpoints } = require("../selectors");
+const { getSelectedSource, getSources } = require("../selectors");
 const { endTruncateStr } = require("../utils/utils");
 
 const App = React.createClass({
   propTypes: {
     sources: PropTypes.object,
     selectedSource: PropTypes.object,
-    selectSource: PropTypes.func,
-    breakpoints: PropTypes.object
+    selectSource: PropTypes.func
   },
 
   displayName: "App",
@@ -122,7 +121,6 @@ const App = React.createClass({
 
 module.exports = connect(
   state => ({ sources: getSources(state),
-              breakpoints: getBreakpoints(state),
               selectedSource: getSelectedSource(state) }),
   dispatch => bindActionCreators(actions, dispatch)
 )(App);

--- a/public/js/components/Breakpoints.js
+++ b/public/js/components/Breakpoints.js
@@ -14,16 +14,16 @@ require("./Breakpoints.css");
 
 function isCurrentlyPausedAtBreakpoint(state, breakpoint) {
   const pause = getPause(state);
-
   if (!pause || pause.get("isInterrupted")) {
     return false;
   }
 
-  const pauseLocation = makeLocationId(
+  const bpId = makeLocationId(breakpoint.location);
+  const pausedId = makeLocationId(
     pause.getIn(["frame", "location"]).toJS()
   );
 
-  return breakpoint.location == pauseLocation;
+  return bpId === pausedId;
 }
 
 const Breakpoints = React.createClass({

--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -9,9 +9,9 @@ const { isFirefox } = require("../feature");
 
 const {
   getSourceText, getBreakpointsForSource,
-  getSelectedSource, getSelectedFrame,
-  makeLocationId
+  getSelectedSource, getSelectedFrame
 } = require("../selectors");
+const { makeLocationId } = require("../reducers/breakpoints");
 const actions = require("../actions");
 const { alignLine, onWheel, resizeBreakpointGutter } = require("../utils/editor");
 const Breakpoint = React.createFactory(require("./EditorBreakpoint"));
@@ -65,7 +65,7 @@ const Editor = React.createClass({
 
   onGutterClick(cm, line, gutter, ev) {
     const bp = this.props.breakpoints.find(b => {
-      return b.getIn(["location", "line"]) === line + 1;
+      return b.location.line === line + 1;
     });
 
     if (bp) {
@@ -140,7 +140,7 @@ const Editor = React.createClass({
 
   render() {
     const breakpoints = this.props.breakpoints.valueSeq()
-          .filter(bp => !bp.get("disabled"));
+          .filter(bp => !bp.disabled);
 
     return (
       dom.div(
@@ -151,7 +151,7 @@ const Editor = React.createClass({
         }),
         breakpoints.map(bp => {
           return Breakpoint({
-            key: makeLocationId(bp.get("location").toJS()),
+            key: makeLocationId(bp.location),
             breakpoint: bp,
             editor: this.editor
           });

--- a/public/js/components/EditorBreakpoint.js
+++ b/public/js/components/EditorBreakpoint.js
@@ -1,5 +1,4 @@
 const React = require("react");
-const ImPropTypes = require("react-immutable-proptypes");
 const { PropTypes } = React;
 
 function makeMarker() {
@@ -21,7 +20,7 @@ function makeMarker() {
 
 const Breakpoint = React.createClass({
   propTypes: {
-    breakpoint: ImPropTypes.map,
+    breakpoint: PropTypes.object,
     editor: PropTypes.object
   },
 
@@ -29,7 +28,7 @@ const Breakpoint = React.createClass({
 
   componentWillMount: function() {
     const bp = this.props.breakpoint;
-    const line = bp.getIn(["location", "line"]) - 1;
+    const line = bp.location.line - 1;
 
     this.props.editor.setGutterMarker(line, "breakpoints", makeMarker());
     this.props.editor.addLineClass(line, "line", "breakpoint");
@@ -37,7 +36,7 @@ const Breakpoint = React.createClass({
 
   componentWillUnmount: function() {
     const bp = this.props.breakpoint;
-    const line = bp.getIn(["location", "line"]) - 1;
+    const line = bp.location.line - 1;
 
     this.props.editor.setGutterMarker(line, "breakpoints", null);
     this.props.editor.removeLineClass(line, "line", "breakpoint");

--- a/public/js/reducers/index.js
+++ b/public/js/reducers/index.js
@@ -12,7 +12,7 @@ const pause = require("./pause");
 module.exports = {
   eventListeners,
   sources: sources.update,
-  breakpoints,
+  breakpoints: breakpoints.update,
   asyncRequests,
   tabs,
   pause

--- a/public/js/reducers/sources.js
+++ b/public/js/reducers/sources.js
@@ -19,10 +19,10 @@ export type SourcesState = {
 };
 
 const State = makeRecord(({
-  sources: I.Map({}),
+  sources: I.Map(),
   selectedSource: undefined,
-  sourcesText: I.Map({}),
-  sourceMaps: I.Map({}),
+  sourcesText: I.Map(),
+  sourceMaps: I.Map(),
   tabs: I.List([])
 } : SourcesState));
 

--- a/public/js/selectors.js
+++ b/public/js/selectors.js
@@ -5,6 +5,7 @@ import type { SourcesState } from "./reducers/sources";
 import type { Location } from "./actions/types";
 
 const sources = require("./reducers/sources");
+const breakpoints = require("./reducers/breakpoints");
 
 type AppState = {
   sources: Record<SourcesState>,
@@ -15,20 +16,6 @@ type AppState = {
 const { isGenerated, getGeneratedSourceLocation, getOriginalSourceUrls,
         isOriginal, getOriginalSourcePosition, getGeneratedSourceId
       } = require("./utils/source-map");
-
-function getBreakpoint(state: AppState, location: Location) {
-  return state.breakpoints.getIn(["breakpoints", makeLocationId(location)]);
-}
-
-function getBreakpoints(state: AppState) {
-  return state.breakpoints.get("breakpoints");
-}
-
-function getBreakpointsForSource(state: AppState, sourceId: string) {
-  return state.breakpoints.get("breakpoints").filter(bp => {
-    return bp.getIn(["location", "sourceId"]) === sourceId;
-  });
-}
 
 function getTabs(state: AppState) {
   return state.tabs.get("tabs");
@@ -123,9 +110,6 @@ function getOriginalSources(state: AppState, source: any) {
 /**
  * @param object - location
  */
-function makeLocationId(location: Location) {
-  return location.sourceId + ":" + location.line.toString();
-}
 
 module.exports = {
   getSource: sources.getSource,
@@ -143,15 +127,15 @@ module.exports = {
   getOriginalSources,
   getSourceMapURL,
 
-  getBreakpoint,
-  getBreakpoints,
-  getBreakpointsForSource,
+  getBreakpoint: breakpoints.getBreakpoint,
+  getBreakpoints: breakpoints.getBreakpoints,
+  getBreakpointsForSource: breakpoints.getBreakpointsForSource,
+
   getTabs,
   getSelectedTab,
   getPause,
   getLoadedObjects,
   getIsWaitingOnBreak,
   getFrames,
-  getSelectedFrame,
-  makeLocationId
+  getSelectedFrame
 };

--- a/public/js/test/fixtures/foobar.json
+++ b/public/js/test/fixtures/foobar.json
@@ -36,18 +36,20 @@
     }
   },
   "breakpoints": {
-    "fooBreakpointActor": {
-      "id": "fooBreakpointActor",
-      "location": {
-        "sourceId": "fooSourceActor",
-        "line": 16
-      }
-    },
-    "barBreakpointActor": {
-      "id": "barBreakpointActor",
-      "location": {
-        "sourceId": "barSourceActor",
-        "line": 18
+    "breakpoints": {
+      "fooBreakpointActor": {
+        "id": "fooBreakpointActor",
+        "location": {
+          "sourceId": "fooSourceActor",
+          "line": 16
+        }
+      },
+      "barBreakpointActor": {
+        "id": "barBreakpointActor",
+        "location": {
+          "sourceId": "barSourceActor",
+          "line": 18
+        }
       }
     }
   }

--- a/public/js/utils/dehydrate-state.js
+++ b/public/js/utils/dehydrate-state.js
@@ -10,7 +10,7 @@ function dehydrate(jsState) {
       sourcesText: fromJS(jsState.sources.sourcesText),
       tabs: fromJS(jsState.sources.tabs)
     }),
-    breakpoints: fromJS(jsState.breakpoints),
+    breakpoints: I.Map(jsState.breakpoints),
     eventListeners: fromJS(jsState.eventListeners),
     pause: jsState.pause ? I.Map({
       pause: fromJS(jsState.pause.pause),

--- a/public/js/utils/dehydrate-state.js
+++ b/public/js/utils/dehydrate-state.js
@@ -1,6 +1,7 @@
 const I = require("immutable");
 const { fromJS } = I;
 const SourcesState = require("../reducers/sources").State;
+const BreakpointsState = require("../reducers/breakpoints").State;
 
 function dehydrate(jsState) {
   return {
@@ -10,7 +11,9 @@ function dehydrate(jsState) {
       sourcesText: fromJS(jsState.sources.sourcesText),
       tabs: fromJS(jsState.sources.tabs)
     }),
-    breakpoints: I.Map(jsState.breakpoints),
+    breakpoints: jsState.breakpoints ? BreakpointsState({
+      breakpoints: I.Map(jsState.breakpoints.breakpoints)
+    }) : null,
     eventListeners: fromJS(jsState.eventListeners),
     pause: jsState.pause ? I.Map({
       pause: fromJS(jsState.pause.pause),

--- a/public/js/utils/makeRecord.js
+++ b/public/js/utils/makeRecord.js
@@ -13,6 +13,8 @@ export type Record<T: Object> = {
   setIn(keyPath: Array<any>, ...iterables: Array<any>): Record<T>;
   merge(values: $Shape<T>): Record<T>;
   mergeIn(keyPath: Array<any>, ...iterables: Array<any>): Record<T>;
+  delete<A>(key: $Keys<T>, value: A): Record<T>;
+  deleteIn(keyPath: Array<any>, ...iterables: Array<any>): Record<T>;
 } & T;
 
 /**

--- a/public/js/utils/utils.js
+++ b/public/js/utils/utils.js
@@ -1,3 +1,4 @@
+// @flow
 /* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
 /* vim: set ft=javascript ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
@@ -7,7 +8,7 @@
 const co = require("co");
 const { isDevelopment } = require("../feature");
 
-function asPaused(client, func) {
+function asPaused(client: any, func: any) {
   if (client.state != "paused") {
     return co(function* () {
       yield client.interrupt();
@@ -29,11 +30,11 @@ function asPaused(client, func) {
   return func();
 }
 
-function handleError(err) {
+function handleError(err: any) {
   console.log("ERROR: ", err);
 }
 
-function promisify(context, method, ...args) {
+function promisify(context: any, method: any, ...args: any) {
   return new Promise((resolve, reject) => {
     args.push(response => {
       if (response.error) {
@@ -46,14 +47,14 @@ function promisify(context, method, ...args) {
   });
 }
 
-function truncateStr(str, size) {
+function truncateStr(str: any, size: any) {
   if (str.length > size) {
     return str.slice(0, size) + "...";
   }
   return str;
 }
 
-function endTruncateStr(str, size) {
+function endTruncateStr(str: any, size: any) {
   if (str.length > size) {
     return "..." + str.slice(str.length - size);
   }
@@ -70,7 +71,7 @@ function endTruncateStr(str, size) {
  * @returns Array
  *          The combined array, in the form [a1, b1, a2, b2, ...]
  */
-function zip(a, b) {
+function zip(a: any, b: any) {
   if (!b) {
     return a;
   }
@@ -94,11 +95,11 @@ function zip(a, b) {
  * @param object obj
  * @returns array
  */
-function entries(obj) {
+function entries(obj: any) {
   return Object.keys(obj).map(k => [k, obj[k]]);
 }
 
-function mapObject(obj, iteratee) {
+function mapObject(obj: any, iteratee: any) {
   return toObject(entries(obj).map(([key, value]) => {
     return [key, iteratee(key, value)];
   }));
@@ -108,7 +109,7 @@ function mapObject(obj, iteratee) {
  * Takes an array of 2-element arrays as key/values pairs and
  * constructs an object using them.
  */
-function toObject(arr) {
+function toObject(arr: any) {
   const obj = {};
   for (let pair of arr) {
     obj[pair[0]] = pair[1];
@@ -125,8 +126,8 @@ function toObject(arr) {
  * @param ...function funcs
  * @returns function
  */
-function compose(...funcs) {
-  return (...args) => {
+function compose(...funcs: any) {
+  return (...args: any) => {
     const initialValue = funcs[funcs.length - 1].apply(null, args);
     const leftFuncs = funcs.slice(0, -1);
     return leftFuncs.reduceRight((composed, f) => f(composed),
@@ -142,6 +143,10 @@ function log() {
   console.log.apply(console, ["[log]", ...arguments]);
 }
 
+function updateObj<T>(obj: T, fields: $Shape<T>) : T {
+  return Object.assign({}, obj, fields);
+}
+
 module.exports = {
   asPaused,
   handleError,
@@ -153,5 +158,6 @@ module.exports = {
   toObject,
   mapObject,
   compose,
-  log
+  log,
+  updateObj
 };


### PR DESCRIPTION
This is a large PR, but it can't really be helped. When converting things from immutable to JS and applying types we need to change everything that uses it.

I want to start writing more tests for the reducers and actions so this helps a lot (and we won't need to update tests if we do these changes now).

A breakpoint in the app state is now a normal JS object. We use it far more than we update it, so it's easier, but the main reason is so that we can have a single `Breakpoint` type and use it everywhere. If we want it to be immutable, we would still use a record type and all the external uses would use normal property lookup (`breakpoint.location`), so we could make that change later if we really wanted.