### PR TITLE
Connect to the Firefox web socket proxy remotely

### DIFF
--- a/bin/firefox-proxy
+++ b/bin/firefox-proxy
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 "use strict";
 
-const minimist = require('minimist');
+const minimist = require("minimist");
 const ws = require("ws");
 const net = require("net");
 
@@ -9,7 +9,8 @@ function proxy(webSocketPort, tcpPort, logging) {
   console.log("Listening for WS on *:" + webSocketPort);
   console.log("Will proxy to TCP on *:" + tcpPort + " on first WS connection");
   if (!logging) {
-    console.log("Protocol messages can be logged by enabling logging.firefoxProtocol in your local.json config");
+    console.log("Protocol messages can be logged by enabling " +
+    "logging.firefoxProtocol in your local.json config");
   }
   let wsServer = new ws.Server({ port: webSocketPort });
   wsServer.on("connection", function onConnection(wsConnection) {
@@ -56,12 +57,11 @@ function proxy(webSocketPort, tcpPort, logging) {
   });
 }
 
-
 const args = minimist(process.argv.slice(2));
 
-const WEB_SOCKET_PORT = args['web-socket-port'] || 9000;
-const TCP_PORT = args['tcp-port'] || 6080;
-const shouldStart = args['start'];
+const WEB_SOCKET_PORT = args["web-socket-port"] || 9000;
+const TCP_PORT = args["tcp-port"] || 6080;
+const shouldStart = args.start;
 
 function start(options) {
   const webSocketPort = options.webSocketPort || 9000;

--- a/public/js/clients/firefox.js
+++ b/public/js/clients/firefox.js
@@ -52,7 +52,7 @@ function connectClient() {
   const portPref = useProxy ? "firefox.proxyPort" : "firefox.webSocketPort";
   const webSocketPort = getValue(portPref);
 
-  const socket = new WebSocket(`ws://localhost:${webSocketPort}`);
+  const socket = new WebSocket(`ws://${document.location.hostname}:${webSocketPort}`);
   const transport = useProxy ?
     new DebuggerTransport(socket) : new WebSocketDebuggerTransport(socket);
   debuggerClient = new DebuggerClient(transport);

--- a/public/js/components/Tabs.js
+++ b/public/js/components/Tabs.js
@@ -42,7 +42,8 @@ function Tabs({ tabs }) {
     return dom.div(
       { className: "not-connected-message" },
       "No remote tabs found. You may be looking to ",
-      dom.a({ href: "/?ws=localhost:5858/node" }, "connect to Node"),
+      dom.a({ href: `/?ws=${document.location.hostname}:9229/node` },
+        "connect to Node"),
       "."
     );
   }
@@ -54,7 +55,7 @@ function Tabs({ tabs }) {
     dom.div(
       { className: "node-message" },
       "You can also ",
-      dom.a({ href: "/?ws=localhost:9229/node" },
+      dom.a({ href: `/?ws=${document.location.hostname}:9229/node` },
             "connect to Node"),
       "."
     )


### PR DESCRIPTION
This is a small change to the Firefox connect lib with some other lint fixes to the `firefox-proxy`.

## Firefox
The web socket connection change allows for another computer (work local network access) to connect to the `firefox-proxy` web socket server and debug Firefox remote-remotely.

## Chrome
I don't have this change working for Chrome debugging yet.  The tab list request is being blocked, possibly because Chrome is connected to localhost doesn't naturally allow external access.  Not sure there is a way around this but I was only targeting Firefox for now.

I should finish with some better error handling for Chrome so when the tab list times out you can continue to work with Firefox.

## Node

A very similar change to the Tabs page allows for Node debugging so I broke that out into a separate commit because the Tabs page is being worked on. #378 