### PR TITLE
(WIP) Save Pretty Print Sources

### DIFF
--- a/public/js/actions/sources.js
+++ b/public/js/actions/sources.js
@@ -14,7 +14,7 @@ const invariant = require("invariant");
 const { isEnabled } = require("../feature");
 
 const { createOriginalSources, getOriginalTexts,
-        createSourceMap } = require("../utils/source-map");
+        createSourceMap, makeOriginalSource } = require("../utils/source-map");
 
 const { getSource, getSourceText, getSourceByURL, getGeneratedSource,
         getSourceMap, getSourceMapURL, getOriginalSources
@@ -56,6 +56,47 @@ function _getOriginalSourceTexts(state, generatedSource, generatedText) {
     const contentType = "text/javascript";
     return { text, id, contentType };
   });
+}
+
+function _addSource(source) {
+  return {
+    type: constants.ADD_SOURCE,
+    source
+  };
+}
+
+async function _prettyPrintSource({ source, sourceText }) {
+  if (!isEnabled("features.prettyPrint")) {
+    return {};
+  }
+
+  const contentType = sourceText ? sourceText.contentType : null;
+  const indent = 2;
+  const url = source.url + ":formatted";
+
+  invariant(
+    isJavaScript(source.url, contentType),
+    "Can't prettify non-javascript files."
+  );
+
+  const { code, mappings } = await workerTask(
+    new Worker("js/utils/pretty-print-worker.js"),
+    {
+      url,
+      indent,
+      source: sourceText.text
+    }
+  );
+
+  let originalSource = makeOriginalSource({
+    url,
+    generatedSource: source,
+    text: { text: code, contentType }
+  });
+
+  createSourceMap({ source, mappings, code });
+
+  return originalSource;
 }
 
 /**
@@ -168,59 +209,24 @@ function blackbox(source, shouldBlackBox) {
 function togglePrettyPrint(id) {
   return ({ dispatch, getState, client }) => {
     const source = getSource(getState(), id).toJS();
-    const wantPretty = !source.isPrettyPrinted;
+
+    if (source.isPrettyPrinted) {
+      return {};
+    }
 
     return dispatch({
       type: constants.TOGGLE_PRETTY_PRINT,
       source: source,
-      [PROMISE]: Task.spawn(function* () {
-        let response;
-
-        if (!isEnabled("features.prettyPrint")) {
-          return {};
-        }
-
-        // Only attempt to pretty print JavaScript sources.
+      [PROMISE]: (async function () {
         const sourceText = getSourceText(getState(), source.id).toJS();
-        const contentType = sourceText ? sourceText.contentType : null;
-        const indent = 2;
-
-        invariant(
-          isJavaScript(source.url, contentType),
-          "Can't prettify non-javascript files."
-        );
-
-        if (wantPretty) {
-          // promisify it
-          // also save the source text with isPromissed so it's easy to cache
-
-          const { code, mappings } = yield workerTask(
-            new Worker("js/utils/pretty-print-worker.js"),
-            {
-              url: source.url,
-              indent,
-              source: sourceText.text
-            }
-          );
-
-          const sourceMap = createSourceMap({
-            source,
-            mappings,
-            code
-          });
-          console.log(sourceMap);
-        }
-        // Remove the cached source AST from the Parser, to avoid getting
-        // wrong locations when searching for functions.
-        // TODO: add Parser dependency
-        // DebuggerController.Parser.clearSource(source.url);
+        const originalSource = await _prettyPrintSource({ source, sourceText });
+        dispatch(_addSource(originalSource));
+        dispatch(selectSource(originalSource.id));
 
         return {
-          isPrettyPrinted: wantPretty,
-          text: response.source,
-          contentType: response.contentType
+          isPrettyPrinted: true
         };
-      })
+      })()
     });
   };
 }

--- a/public/js/actions/tests/loadSourceText.js
+++ b/public/js/actions/tests/loadSourceText.js
@@ -37,7 +37,7 @@ const deferredMockThreadClient = {
         return;
       }
 
-      resolve("ok");
+      resolve({ source: "ok", contentType: "text/javascript" });
     });
   }
 };

--- a/public/js/actions/types.js
+++ b/public/js/actions/types.js
@@ -17,16 +17,17 @@ export type Breakpoint = {
   condition: ?string
 };
 
-export type Source = {
-  id: string,
-  url?: string,
-  sourceMapURL?: string
-};
-
 export type SourceText = {
   id: string,
   text: string,
   contentType: string
+};
+
+export type Source = {
+  id: string,
+  url?: string,
+  sourceMapURL?: string,
+  text?: SourceText
 };
 
 type BreakpointAction =

--- a/public/js/actions/types.js
+++ b/public/js/actions/types.js
@@ -26,8 +26,7 @@ export type SourceText = {
 export type Source = {
   id: string,
   url?: string,
-  sourceMapURL?: string,
-  text?: SourceText
+  sourceMapURL?: string
 };
 
 type BreakpointAction =
@@ -68,11 +67,11 @@ type SourceAction =
       value: { isBlackBoxed: boolean }}
   | { type: "TOGGLE_PRETTY_PRINT",
       source: Source,
+      originalSource: Source,
       status: AsyncStatus,
       error: string,
       value: { isPrettyPrinted: boolean,
-               text: string,
-               contentType: string }}
+               sourceText: SourceText }}
   | { type: "CLOSE_TAB", id: string };
 
 export type Action =

--- a/public/js/reducers/sources.js
+++ b/public/js/reducers/sources.js
@@ -13,6 +13,7 @@ import type { Record } from "../utils/makeRecord";
 export type SourcesState = {
   sources: I.Map<string, any>,
   selectedSource: ?any,
+  sourcesText: I.Map<string, any>,
   tabs: I.List<any>,
   sourceMaps: I.Map<string, any>,
 };
@@ -20,6 +21,7 @@ export type SourcesState = {
 const State = makeRecord(({
   sources: I.Map(),
   selectedSource: undefined,
+  sourcesText: I.Map(),
   sourceMaps: I.Map(),
   tabs: I.List([])
 } : SourcesState));
@@ -84,13 +86,14 @@ function update(state = State(), action: Action) : Record<SourcesState> {
 
     case "TOGGLE_PRETTY_PRINT":
       if (action.status === "done") {
-        return state.setIn(
-          ["sources", action.source.id, "isPrettyPrinted"],
-          action.value.isPrettyPrinted
-        );
+        return _updateText(state, action, [action.value.sourceText])
+          .setIn(
+            ["sources", action.source.id, "isPrettyPrinted"],
+            action.value.isPrettyPrinted
+          );
       }
 
-      break;
+      return _updateText(state, action, [action.originalSource]);
     case "NAVIGATE":
       // Reset the entire state to just the initial state, a blank state
       // if you will.
@@ -100,33 +103,36 @@ function update(state = State(), action: Action) : Record<SourcesState> {
   return state;
 }
 
-function removeSourceFromTabList(state, id) {
-  return state.tabs.filter(tab => tab.get("id") != id);
-}
-
 function _updateText(state, action, values) : Record<SourcesState> {
   if (action.status === "start") {
-    return values.reduce((_state, source: Source) => {
-      return _state.setIn(["sources", source.id, "text"], I.Map({
+    // Merge this in, don't set it. That way the previous value is
+    // still stored here, and we can retrieve it if whatever we're
+    // doing fails.
+    return values.reduce((_state, source: any) => {
+      return _state.mergeIn(["sourcesText", source.id], {
         loading: true
-      }));
+      });
     }, state);
   }
 
   if (action.status === "error") {
-    return values.reduce((_state, source: Source) => {
-      return _state.setIn(["sources", source.id, "text"], I.Map({
+    return values.reduce((_state, source: any) => {
+      return _state.setIn(["sourcesText", source.id], I.Map({
         error: action.error
       }));
     }, state);
   }
 
   return values.reduce((_state, sourceText: SourceText) => {
-    return _state.setIn(["sources", sourceText.id, "text"], I.Map({
+    return _state.setIn(["sourcesText", sourceText.id], I.Map({
       text: sourceText.text,
       contentType: sourceText.contentType
     }));
   }, state);
+}
+
+function removeSourceFromTabList(state, id) {
+  return state.tabs.filter(tab => tab.get("id") != id);
 }
 
 /*
@@ -208,13 +214,7 @@ function getSources(state: OuterState) {
 }
 
 function getSourceText(state: OuterState, id: string) {
-  const source = getSource(state, id);
-
-  if (!source) {
-    return;
-  }
-
-  return source.get("text"); // eslint-disable-line consistent-return
+  return state.sources.sourcesText.get(id);
 }
 
 function getSourceTabs(state: OuterState) {

--- a/public/js/types.js
+++ b/public/js/types.js
@@ -8,11 +8,17 @@ const Tab = t.struct({
   browser: t.enums.of(["chrome", "firefox"])
 }, "Tab");
 
+const SourceText = t.struct({
+  text: t.String,
+  contentType: t.String
+});
+
 const Source = t.struct({
   id: t.String,
   url: t.union([t.String, t.Nil]),
   isPrettyPrinted: t.Boolean,
-  sourceMapURL: t.union([t.String, t.Nil])
+  sourceMapURL: t.union([t.String, t.Nil]),
+  text: t.maybe(SourceText)
 }, "Source");
 
 const Location = t.struct({
@@ -44,6 +50,7 @@ const Frame = t.struct({
 module.exports = {
   Tab,
   Source,
+  SourceText,
   Location,
   Breakpoint,
   BreakpointResult,

--- a/public/js/types.js
+++ b/public/js/types.js
@@ -17,8 +17,7 @@ const Source = t.struct({
   id: t.String,
   url: t.union([t.String, t.Nil]),
   isPrettyPrinted: t.Boolean,
-  sourceMapURL: t.union([t.String, t.Nil]),
-  text: t.maybe(SourceText)
+  sourceMapURL: t.union([t.String, t.Nil])
 }, "Source");
 
 const Location = t.struct({

--- a/public/js/utils/source-map.js
+++ b/public/js/utils/source-map.js
@@ -109,17 +109,16 @@ function createOriginalSources(generatedSource, sourceMap) {
 
   return getOriginalSourceUrls(generatedSource)
     .map((url, index) => makeOriginalSource({
-      generatedSource,
+      source: generatedSource,
       url,
       id: index
     }));
 }
 
-function makeOriginalSource({ url, generatedSource, id = 1, text = null }) {
-  const generatedSourceId = generatedSource.id;
+function makeOriginalSource({ url, source, id = 1 }) {
+  const generatedSourceId = source.id;
   return {
     url,
-    text,
     id: JSON.stringify({ generatedSourceId, id }),
     isPrettyPrinted: false
   };


### PR DESCRIPTION
**do not merge**

WIP pretty print patch for saving pretty sources and showing them in the editor w/ breakpoint support.

Architecture:
* saves a new "pretty" source, with a different url and id. Works well for source maps as the map points from ugly source to pretty source
* locations do a better job of maintaining column data, which is useful for going from generated locations to original locations when the server comes back with an actual breakpoint location.
* moves source text from a state field to a source field. I found it simpler to reason about and the patch was minor. I prefer thinking about sources w/ text that could either be not loaded, loading, done, but it's not a big deal
* caching came for free.

What works well:
* source is shown
* breakpoints work
* tabs reflect different sources

What's yet to do:
* source tree shows the formatted source
* the formatted source has a pretty button. should be hidden
* clean up the code, it's kinda a mess


![screen shot 2016-07-25 at 6 20 50 pm](https://cloud.githubusercontent.com/assets/254562/17119521/6bf0316c-5294-11e6-9b64-b46e709e4974.png)
