### PR TITLE
handle debugger statements like breakpoints?

### DIFF
--- a/public/js/reducers/breakpoints.js
+++ b/public/js/reducers/breakpoints.js
@@ -42,6 +42,23 @@ function makeLocationId(location: Location) {
 
 function update(state = State(), action: Action) {
   switch (action.type) {
+    case "PAUSED": {
+      const pause = action.pauseInfo;
+      if (pause.why.type === "debuggerStatement") {
+        const locationId = makeLocationId(pause.frame.location);
+        const frameId = pause.frame.id;
+        const bp = state.breakpoints.get(locationId) ||
+          { location: pause.frame.location, condition: undefined };
+        const text = "debugger statement";
+        return state.setIn(["breakpoints", locationId], updateObj(bp, {
+          id: frameId,
+          disabled: false,
+          loading: false,
+          text: text
+        }));
+      }
+      break;
+    }
     case "ADD_BREAKPOINT": {
       const id = makeLocationId(action.breakpoint.location);
 


### PR DESCRIPTION
**not for merge**

I put this together last night really quickly.   I just wanted to offer it up to others and to gather feedback / discussion on the ideas / approach so we could handle it in the future.

As you can see the debugger already handles the paused state well when it encounters a `debugger;` statement in the code; the editor opens to it and highlights it.  However because it isn't a breakpoint set by the debugger it works very differently even though it is fairly similar to a breakpoint from the user perspective.

![screen shot 2016-07-26 at 10 23 25](https://cloud.githubusercontent.com/assets/2134/17148305/78c25f32-531b-11e6-8b32-0cb3f85531b1.png)

The change as implemented listens for the `PAUSED` action and specifically for the one that is related to a `debugger;` statement in the code; defined as `"debuggerStatement"` from the Firefox client.  This listening happens in the breakpoints reducer and creates a breakpoint in the state.

So the question is:
> Should debugger statements appear and act as breakpoints?

If so:
* can they be disabled by the debugger?
* should they have a market in the editor?
 * can they be disabled from here?
 * is it a different kind of marker?
* should they appear in the breakpoints list?
 * how are they labeled?
 * can they be disabled from here?