### PR TITLE
Drop eslint constent-return

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -91,8 +91,6 @@
     "comma-style": [2, "last"],
     // Warn about cyclomatic complexity in functions.
     "complexity": 2,
-    // Require return statements to either always or never specify values.
-    "consistent-return": 2,
     // Don't warn for inconsistent naming when capturing this (not so important
     // with auto-binding fat arrow functions).
     "consistent-this": 0,


### PR DESCRIPTION
This rule makes it difficult for functions to return null values e.g.

```js
function getSourceId(id) {
  const source = findSource(id);
  
  if (!source) {
     return;
  } 

  return source.id
}
```

More importantly, this rule is less expressive than what is possible with flow typing returns.
