### PR TITLE
Debounce Sources Tree

### DIFF
--- a/public/js/actions/sources.js
+++ b/public/js/actions/sources.js
@@ -20,25 +20,6 @@ const { getSource, getSourceText, getSourceByURL, getGeneratedSource,
         getSourceMap, getSourceMapURL, getOriginalSources
       } = require("../selectors");
 
-/**
- * Throttles source dispatching to reduce rendering churn.
- */
-let newSources = [];
-let newSourceTimeout;
-
-function _queueSourcesDispatch(dispatch) {
-  if (!newSourceTimeout) {
-    // Even just batching every 10ms works because we just want to
-    // group sources that come in at once.
-    newSourceTimeout = setTimeout(() => {
-      dispatch({ type: constants.ADD_SOURCES,
-                 sources: newSources });
-      newSources = [];
-      newSourceTimeout = null;
-    }, 10);
-  }
-}
-
 function _shouldSourceMap(generatedSource) {
   return isEnabled("features.sourceMaps") && generatedSource.sourceMapURL;
 }
@@ -58,6 +39,13 @@ function _getOriginalSourceTexts(state, generatedSource, generatedText) {
   });
 }
 
+function _addSource(source) {
+  return {
+    type: constants.ADD_SOURCE,
+    source
+  };
+}
+
 /**
  * Handler for the debugger client's unsolicited newSource notification.
  */
@@ -67,11 +55,7 @@ function newSource(source) {
       dispatch(loadSourceMap(source));
     }
 
-    // We don't immediately dispatch the source because several
-    // thousand may come in at the same time and we want to batch
-    // rendering.
-    newSources.push(source);
-    _queueSourcesDispatch(dispatch);
+    dispatch(_addSource(source));
   };
 }
 

--- a/public/js/components/SourcesTree.js
+++ b/public/js/components/SourcesTree.js
@@ -15,7 +15,24 @@ const ManagedTree = React.createFactory(require("./utils/ManagedTree"));
 const FolderIcon = React.createFactory(require("./utils/Icons").FolderIcon);
 const DomainIcon = React.createFactory(require("./utils/Icons").DomainIcon);
 const FileIcon = React.createFactory(require("./utils/Icons").FileIcon);
-const WorkerIcon = React.createFactory(require("./utils/Icons").WorkerIcon);
+
+const folder = FolderIcon({
+  className: classnames(
+    "folder"
+  )
+});
+
+const domain = DomainIcon({
+  className: classnames(
+    "domain"
+  )
+});
+
+const file = FileIcon({
+  className: classnames(
+    "file"
+  )
+});
 
 let SourcesTree = React.createClass({
   propTypes: {
@@ -30,33 +47,35 @@ let SourcesTree = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.sources !== this.props.sources) {
-      if (nextProps.sources.size === 0) {
-        this.setState(createTree(nextProps.sources));
-        return;
-      }
-
-      const next = Set(nextProps.sources.valueSeq());
-      const prev = Set(this.props.sources.valueSeq());
-      const newSet = next.subtract(prev);
-
-      const uncollapsedTree = this.state.uncollapsedTree;
-      for (let source of newSet) {
-        addToTree(uncollapsedTree, source);
-      }
-
-      // TODO: recreating the tree every time messes with the expanded
-      // state of ManagedTree, because it depends on item instances
-      // being the same. The result is that if a source is added at a
-      // later time, all expanded state is lost.
-      const sourceTree = newSet.size > 0
-            ? collapseTree(uncollapsedTree)
-            : this.state.sourceTree;
-
-      this.setState({ uncollapsedTree,
-                      sourceTree,
-                      parentMap: createParentMap(sourceTree) });
+    if (nextProps.sources === this.props.sources) {
+      return;
     }
+
+    if (nextProps.sources.size === 0) {
+      this.setState(createTree(nextProps.sources));
+      return;
+    }
+
+    const next = Set(nextProps.sources.valueSeq());
+    const prev = Set(this.props.sources.valueSeq());
+    const newSet = next.subtract(prev);
+
+    const uncollapsedTree = this.state.uncollapsedTree;
+    for (let source of newSet) {
+      addToTree(uncollapsedTree, source);
+    }
+
+    // TODO: recreating the tree every time messes with the expanded
+    // state of ManagedTree, because it depends on item instances
+    // being the same. The result is that if a source is added at a
+    // later time, all expanded state is lost.
+    const sourceTree = newSet.size > 0
+          ? collapseTree(uncollapsedTree)
+          : this.state.sourceTree;
+
+    this.setState({ uncollapsedTree,
+                    sourceTree,
+                    parentMap: createParentMap(sourceTree) });
   },
 
   focusItem(item) {
@@ -67,6 +86,18 @@ let SourcesTree = React.createClass({
     if (!nodeHasChildren(item)) {
       this.props.selectSource(item.contents.get("id"));
     }
+  },
+
+  getIcon(item, depth) {
+    if (depth === 0) {
+      return domain;
+    }
+
+    if (!nodeHasChildren(item)) {
+      return file;
+    }
+
+    return folder;
   },
 
   renderItem(item, depth, focused, _, expanded, { setExpanded }) {
@@ -81,39 +112,7 @@ let SourcesTree = React.createClass({
       }
     });
 
-    const folder = FolderIcon({
-      className: classnames(
-        "folder"
-      )
-    });
-
-    const domain = DomainIcon({
-      className: classnames(
-        "domain"
-      )
-    });
-
-    const file = FileIcon({
-      className: classnames(
-        "file"
-      )
-    });
-
-    const worker = WorkerIcon({
-      className: classnames(
-        "worker"
-      )
-    });
-
-    let icon = worker;
-
-    if (depth === 0) {
-      icon = domain;
-    } else if (!nodeHasChildren(item)) {
-      icon = file;
-    } else {
-      icon = folder;
-    }
+    const icon = this.getIcon(item, depth);
 
     return dom.div(
       {

--- a/public/js/components/SourcesTree.js
+++ b/public/js/components/SourcesTree.js
@@ -10,6 +10,7 @@ const classnames = require("classnames");
 const ImPropTypes = require("react-immutable-proptypes");
 const Arrow = React.createFactory(require("./utils/Arrow"));
 const { Set } = require("immutable");
+const debounce = require("lodash/debounce");
 
 const ManagedTree = React.createFactory(require("./utils/ManagedTree"));
 const FolderIcon = React.createFactory(require("./utils/Icons").FolderIcon);
@@ -46,6 +47,15 @@ let SourcesTree = React.createClass({
     return createTree(this.props.sources);
   },
 
+  componentWillMount() {
+    this.debouncedUpdate = debounce(this.debouncedUpdate, 20);
+  },
+
+  shouldComponentUpdate() {
+    this.debouncedUpdate();
+    return false;
+  },
+
   componentWillReceiveProps(nextProps) {
     if (nextProps.sources === this.props.sources) {
       return;
@@ -76,6 +86,14 @@ let SourcesTree = React.createClass({
     this.setState({ uncollapsedTree,
                     sourceTree,
                     parentMap: createParentMap(sourceTree) });
+  },
+
+  debouncedUpdate() {
+    if (!this.isMounted()) {
+      return;
+    }
+
+    this.forceUpdate();
   },
 
   focusItem(item) {


### PR DESCRIPTION
This should fix #246 and #245.

The big change here is that we're going from debouncing newSource actions to debouncing the source tree render.

Why is this better:
+ the order of client events matters. by debouncing `newSource` actions it's possible a `pause` action is dispatched before the sources have been stored. When this happens `selectSource` is dispatched before the source is stored. 
+ Ultimately, the problem we should be solving is render performance for the source tree and there are many ways to do that. This is a simple approach for this case, if other components also need to have renders throttled, we can re-evaluate.

Disclaimer:
+ This causes the sources tree to always be collapsed. I think we can fix this after this work lands, but I quickly looked into it. What I found was a strange behavior where without the debouce behavior, SourcesTree.render was called an even number of time for depth 0 nodes, each time an item was called isExpanded would be flipped. This behavior is very odd and should be fixed to be based on whether an item has children.
