### PR TITLE
denormalize sourceText

### DIFF
--- a/public/js/actions/types.js
+++ b/public/js/actions/types.js
@@ -26,7 +26,8 @@ export type SourceText = {
 export type Source = {
   id: string,
   url?: string,
-  sourceMapURL?: string
+  sourceMapURL?: string,
+  text?: SourceText
 };
 
 type BreakpointAction =
@@ -67,11 +68,11 @@ type SourceAction =
       value: { isBlackBoxed: boolean }}
   | { type: "TOGGLE_PRETTY_PRINT",
       source: Source,
-      originalSource: Source,
       status: AsyncStatus,
       error: string,
       value: { isPrettyPrinted: boolean,
-               sourceText: SourceText }}
+               text: string,
+               contentType: string }}
   | { type: "CLOSE_TAB", id: string };
 
 export type Action =

--- a/public/js/reducers/sources.js
+++ b/public/js/reducers/sources.js
@@ -13,7 +13,6 @@ import type { Record } from "../utils/makeRecord";
 export type SourcesState = {
   sources: I.Map<string, any>,
   selectedSource: ?any,
-  sourcesText: I.Map<string, any>,
   tabs: I.List<any>,
   sourceMaps: I.Map<string, any>,
 };
@@ -21,7 +20,6 @@ export type SourcesState = {
 const State = makeRecord(({
   sources: I.Map(),
   selectedSource: undefined,
-  sourcesText: I.Map(),
   sourceMaps: I.Map(),
   tabs: I.List([])
 } : SourcesState));
@@ -86,14 +84,13 @@ function update(state = State(), action: Action) : Record<SourcesState> {
 
     case "TOGGLE_PRETTY_PRINT":
       if (action.status === "done") {
-        return _updateText(state, action, [action.value.sourceText])
-          .setIn(
-            ["sources", action.source.id, "isPrettyPrinted"],
-            action.value.isPrettyPrinted
-          );
+        return state.setIn(
+          ["sources", action.source.id, "isPrettyPrinted"],
+          action.value.isPrettyPrinted
+        );
       }
 
-      return _updateText(state, action, [action.originalSource]);
+      break;
     case "NAVIGATE":
       // Reset the entire state to just the initial state, a blank state
       // if you will.
@@ -103,36 +100,33 @@ function update(state = State(), action: Action) : Record<SourcesState> {
   return state;
 }
 
+function removeSourceFromTabList(state, id) {
+  return state.tabs.filter(tab => tab.get("id") != id);
+}
+
 function _updateText(state, action, values) : Record<SourcesState> {
   if (action.status === "start") {
-    // Merge this in, don't set it. That way the previous value is
-    // still stored here, and we can retrieve it if whatever we're
-    // doing fails.
-    return values.reduce((_state, source: any) => {
-      return _state.mergeIn(["sourcesText", source.id], {
+    return values.reduce((_state, source: Source) => {
+      return _state.setIn(["sources", source.id, "text"], I.Map({
         loading: true
-      });
+      }));
     }, state);
   }
 
   if (action.status === "error") {
-    return values.reduce((_state, source: any) => {
-      return _state.setIn(["sourcesText", source.id], I.Map({
+    return values.reduce((_state, source: Source) => {
+      return _state.setIn(["sources", source.id, "text"], I.Map({
         error: action.error
       }));
     }, state);
   }
 
   return values.reduce((_state, sourceText: SourceText) => {
-    return _state.setIn(["sourcesText", sourceText.id], I.Map({
+    return _state.setIn(["sources", sourceText.id, "text"], I.Map({
       text: sourceText.text,
       contentType: sourceText.contentType
     }));
   }, state);
-}
-
-function removeSourceFromTabList(state, id) {
-  return state.tabs.filter(tab => tab.get("id") != id);
 }
 
 /*
@@ -214,7 +208,13 @@ function getSources(state: OuterState) {
 }
 
 function getSourceText(state: OuterState, id: string) {
-  return state.sources.sourcesText.get(id);
+  const source = getSource(state, id);
+
+  if (!source) {
+    return;
+  }
+
+  return source.get("text"); // eslint-disable-line consistent-return
 }
 
 function getSourceTabs(state: OuterState) {

--- a/public/js/types.js
+++ b/public/js/types.js
@@ -17,7 +17,8 @@ const Source = t.struct({
   id: t.String,
   url: t.union([t.String, t.Nil]),
   isPrettyPrinted: t.Boolean,
-  sourceMapURL: t.union([t.String, t.Nil])
+  sourceMapURL: t.union([t.String, t.Nil]),
+  text: t.maybe(SourceText)
 }, "Source");
 
 const Location = t.struct({

--- a/public/js/utils/source-map.js
+++ b/public/js/utils/source-map.js
@@ -109,16 +109,17 @@ function createOriginalSources(generatedSource, sourceMap) {
 
   return getOriginalSourceUrls(generatedSource)
     .map((url, index) => makeOriginalSource({
-      source: generatedSource,
+      generatedSource,
       url,
       id: index
     }));
 }
 
-function makeOriginalSource({ url, source, id = 1 }) {
-  const generatedSourceId = source.id;
+function makeOriginalSource({ url, generatedSource, id = 1, text = null }) {
+  const generatedSourceId = generatedSource.id;
   return {
     url,
+    text,
     id: JSON.stringify({ generatedSourceId, id }),
     isPrettyPrinted: false
   };


### PR DESCRIPTION
This is a follow up on the earlier discussion about de-normalizing `sourceText`.

This PR, moves sourceText from the store to a field in source. The field name is `text`, which is a poor name. I think I would prefer calling it text with a content field.

Benefits:
+ when sourceText is separate, we need to make sure that there's always a sourceText object when we want to select a source. This is a timing issue with pretty printing.

+ The reducers are simpler when they're just sources with text. 

Testing:
+ If the unit tests pre-loaded data w/ client events like `newSource(protocolFixture["backbone"])` the data would be properly setup

DISCLAIMER: I'm raising this PR so that we can discuss it. If we're not comfortable creating a more abstract store then we shouldn't. There are pros/cons in both directions and it's simpler to keep the store closer to the protocol for now, if we're not certain. 