### PR TITLE
(discussion) Add translate function

### DIFF
--- a/public/js/components/App.css
+++ b/public/js/components/App.css
@@ -76,3 +76,10 @@ body {
   text-align: center;
   width: 100%;
 }
+
+.translate-string {
+  /*
+  background-color: red;
+  color: yellow;
+  */
+}

--- a/public/js/components/Tabs.js
+++ b/public/js/components/Tabs.js
@@ -1,6 +1,7 @@
 const React = require("react");
 const { connect } = require("react-redux");
 const { getTabs } = require("../selectors");
+const { translate } = require("../utils/translate");
 
 require("./Tabs.css");
 const dom = React.DOM;
@@ -10,13 +11,13 @@ function getTabsByBrowser(tabs, browser) {
     .filter(tab => tab.get("browser") == browser);
 }
 
-function renderTabs(tabTitle, tabs, paramName) {
+function renderTabs(tabTitle, tabs, paramName, tabsClass) {
   if (tabs.count() == 0) {
     return null;
   }
 
   return dom.div(
-    { className: `tab-group ${tabTitle}` },
+    { className: `tab-group ${tabsClass}` },
     dom.div(
       { className: "tab-group-title" }, tabTitle),
     dom.ul(
@@ -41,23 +42,29 @@ function Tabs({ tabs }) {
   if (tabs.isEmpty()) {
     return dom.div(
       { className: "not-connected-message" },
-      "No remote tabs found. You may be looking to ",
+      translate("No remote tabs found. You may be looking to "),
       dom.a({ href: `/?ws=${document.location.hostname}:9229/node` },
-        "connect to Node"),
+        translate("connect to Node")),
       "."
     );
   }
 
   return dom.div(
     { className: "tabs theme-light" },
-    renderTabs("Firefox Tabs", firefoxTabs, "firefox-tab"),
-    renderTabs("Chrome Tabs", chromeTabs, "chrome-tab"),
+    renderTabs(
+      translate("Firefox Tabs"), firefoxTabs, "firefox-tab", "Firefox"),
+    renderTabs(
+      translate("Chrome Tabs"), chromeTabs, "chrome-tab", "Chrome"),
     dom.div(
       { className: "node-message" },
-      "You can also ",
-      dom.a({ href: `/?ws=${document.location.hostname}:9229/node` },
-            "connect to Node"),
-      "."
+      translate(
+        "You can also ",
+        dom.a(
+          { href: `/?ws=${document.location.hostname}:9229/node` },
+          "connect to Node"
+        ),
+        "."
+      )
     )
   );
 }

--- a/public/js/utils/translate.js
+++ b/public/js/utils/translate.js
@@ -1,0 +1,10 @@
+const React = require("react");
+const { DOM: dom } = React;
+
+function translate() {
+  return dom.span({ className: "translate-string" }, ...arguments);
+}
+
+module.exports = {
+  translate
+};


### PR DESCRIPTION
One of the big blockers for landing the new debugger is translating our strings with l10n. 

The approach we're planning on taking advantage of is a function that is a no-op in local development and l10n in the panel. 

I started working on the no-op function which will let us make sure we have string coverage before we land in the panel.

Notice the styles that highlight the matched text in an obnoxious red. The goal here is that when we want to check it should be easy to see the strings.

![screen shot 2016-07-28 at 6 09 51 pm](https://cloud.githubusercontent.com/assets/254562/17231192/6c011d9a-54ee-11e6-8b93-24faa4694850.png)
