### PR TITLE
(wip) tweaks to make workers work in Firefox context

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -6,15 +6,16 @@ const path = require("path");
 
 const firefoxPanel = require("./firefox-panel.json");
 const development = require("./development.json");
-const envConfig = process.env.NODE_ENV === "production" ?
-   firefoxPanel : development;
 
 const localConfig = fs.existsSync(path.join(__dirname, "./local.json")) ?
   require("./local.json") : {};
 
-let config = _.merge({}, envConfig, localConfig);
+let config = _.merge({}, development, localConfig);
 
-function getConfig() {
+function getConfig(target) {
+  if(target === "firefox-panel") {
+    return _.merge({}, firefoxPanel, localConfig);
+  }
   return config;
 }
 

--- a/config/development.json
+++ b/config/development.json
@@ -1,5 +1,6 @@
 {
   "environment": "development",
+  "baseWorkerURL": "public/build/",
   "logging": {
     "client": false,
     "firefoxProxy": false

--- a/config/firefox-panel.json
+++ b/config/firefox-panel.json
@@ -1,5 +1,6 @@
 {
   "environment": "firefox-panel",
+  "baseWorkerURL": "resource://devtools/client/debugger/new/",
   "logging": false,
   "clientLogging": false,
   "features": {

--- a/public/js/selectors.js
+++ b/public/js/selectors.js
@@ -46,8 +46,7 @@ function getSelectedFrame(state: AppState) {
 }
 
 function getSourceMapURL(state: AppState, source: any) {
-  const tab = getSelectedTab(state);
-  return tab.get("url") + "/" + source.sourceMapURL;
+  return source.url + "/" + source.sourceMapURL;
 }
 
 /**

--- a/public/js/utils/source-map.js
+++ b/public/js/utils/source-map.js
@@ -3,9 +3,9 @@ const { workerTask } = require("./utils");
 import type { Location } from "./actions/types";
 
 const { getSource, getSourceByURL } = require("../selectors");
-const { isEnabled } = require("../feature");
+const { isEnabled, getValue } = require("../feature");
 
-const sourceMapWorker = new Worker("public/build/source-map-worker.js");
+const sourceMapWorker = new Worker(getValue("baseWorkerURL") + "source-map-worker.js");
 const sourceMapTask = function(method) {
   return function() {
     const args = Array.prototype.slice.call(arguments);

--- a/webpack.config.devtools.js
+++ b/webpack.config.devtools.js
@@ -26,10 +26,10 @@ const plugins = webpackConfig.plugins.filter(p => !(p instanceof DefinePlugin));
 webpackConfig.plugins = plugins.concat([
   new webpack.DefinePlugin({
     "process.env": {
-      NODE_ENV: JSON.stringify("production"),
+      NODE_ENV: JSON.stringify(process.env.NODE_ENV || "production"),
     },
     "DebuggerTarget": JSON.stringify("firefox-panel"),
-    "DebuggerConfig": JSON.stringify(getConfig())
+    "DebuggerConfig": JSON.stringify(getConfig("firefox-panel"))
   })
 ]);
 


### PR DESCRIPTION
I had a little difficulty making this work. The config system feels a bit awkward, and hard to figure out what's pulling in what. We can't pull in the firefox config if `process.env.NODE_ENV === "production"`, because that value has nothing to do with the target. We should be able to run dev/prod locally, and dev/prod in Firefox.

The problem is that we pull in config for firefox at build time, so `DebuggerTarget` does not exist because that's defined at build time. I had to add a parameter to `getConfig` but I don't love it. Just wanted to show what's needed; we can tweak this after feedback into something merge-able.