### PR TITLE
Right Sidebar element wrapping (#439)

### DIFF
--- a/public/js/components/RightSidebar.css
+++ b/public/js/components/RightSidebar.css
@@ -1,11 +1,13 @@
 .right-sidebar {
   flex: 1;
+  white-space: nowrap;
 }
 
 .command-bar {
   border-bottom: 1px solid #cccccc;
   height: 30px;
   padding: 8px 5px 10px 10px;
+  overflow: hidden;
 }
 
 .command-bar > span {


### PR DESCRIPTION
I just added to the right side bar css file. I am having issues testing in chrome but this appears to work in Firefox. Note that when you pause on a breakpoint we still get a one line wrap on the source name but I would think that is what you would want it to do.